### PR TITLE
Enhance scanning and introspection for assertion info

### DIFF
--- a/code/include/fossil/unittest/internal.h
+++ b/code/include/fossil/unittest/internal.h
@@ -224,6 +224,7 @@ typedef struct {
     bool shoudl_timeout;   /**< Flag indicating whether the test case should timeout (1 for true, 0 for false). */
     bool should_fail;      /**< Flag indicating whether the test case should fail (1 for true, 0 for false). */
     bool has_assert;       /**< Flag indicating if an assertion occurred (1 for true, 0 for false). */
+    bool same_assert;      /**< Flag indicating if the test case is the same (1 for true, 0 for false). */
     int32_t num_asserts;   /**< Number of assertions that occurred. */
     int32_t line;          /**< Line number where the assertion occurred. */
     char *func;            /**< Function name where the assertion occurred. */

--- a/code/include/fossil/unittest/internal.h
+++ b/code/include/fossil/unittest/internal.h
@@ -224,6 +224,7 @@ typedef struct {
     bool shoudl_timeout;   /**< Flag indicating whether the test case should timeout (1 for true, 0 for false). */
     bool should_fail;      /**< Flag indicating whether the test case should fail (1 for true, 0 for false). */
     bool has_assert;       /**< Flag indicating if an assertion occurred (1 for true, 0 for false). */
+    int32_t num_asserts;   /**< Number of assertions that occurred. */
     int32_t line;          /**< Line number where the assertion occurred. */
     char *func;            /**< Function name where the assertion occurred. */
     char *file;            /**< File name where the assertion occurred. */

--- a/code/source/unittest/console.c
+++ b/code/source/unittest/console.c
@@ -402,11 +402,15 @@ void fossil_test_io_unittest_then(char *description) {
 
 void fossil_test_io_unittest_step(xassert_info *assume) {
     if (_CLI.verbose_level == 2) {
-        fossil_test_cout("blue", "has assert: ");
+        fossil_test_cout("blue", "has assert  : ");
         fossil_test_cout("cyan", " -> %s\n", assume->has_assert ? COLOR_GREEN "has assertions" COLOR_RESET : COLOR_RED "missing assertions" COLOR_RESET);
+        fossil_test_cout("blue", "asserts used: ");
+        fossil_test_cout("cyan", COLOR_GREEN "%3i\n" COLOR_RESET , assume->num_asserts);
     } else if (_CLI.verbose_level == 1) {
-        fossil_test_cout("blue", "[intro] has_assert: ");
+        fossil_test_cout("blue", "[intro] has_assert : ");
         fossil_test_cout("cyan", "%s\n", assume->has_assert ? COLOR_GREEN "yes" COLOR_RESET : COLOR_RED "no" COLOR_RESET);
+        fossil_test_cout("blue", "[intro] num_asserts: ");
+        fossil_test_cout("cyan", COLOR_GREEN "%3i\n" COLOR_RESET , assume->num_asserts);
     }
 }
 

--- a/code/source/unittest/console.c
+++ b/code/source/unittest/console.c
@@ -409,6 +409,8 @@ void fossil_test_io_unittest_step(xassert_info *assume) {
     } else if (_CLI.verbose_level == 1) {
         fossil_test_cout("blue", "[intro] has_assert : ");
         fossil_test_cout("cyan", "%s\n", assume->has_assert ? COLOR_GREEN "yes" COLOR_RESET : COLOR_RED "no" COLOR_RESET);
+        fossil_test_cout("blue", "[intro] same_assert: ");
+        fossil_test_cout("cyan", "%s\n", assume->same_assert ? COLOR_RED "yes" COLOR_RESET : COLOR_GREEN "no" COLOR_RESET);
         fossil_test_cout("blue", "[intro] num_asserts: ");
         fossil_test_cout("cyan", COLOR_GREEN "%3i\n" COLOR_RESET , assume->num_asserts);
     }

--- a/code/source/unittest/unittest.c
+++ b/code/source/unittest/unittest.c
@@ -391,6 +391,7 @@ void fossil_test_run_testcase(fossil_test_t *test) {
     _ASSERT_INFO.has_assert     = false;
     _ASSERT_INFO.should_fail    = false;
     _ASSERT_INFO.shoudl_timeout = false;
+    _ASSERT_INFO.num_asserts    = 0;
 
     if (_TEST_ENV.rule.skipped && strcmp(test->marks, "skip") == 0) {
         return;
@@ -720,5 +721,6 @@ void _fossil_test_assert_class(bool expression, xassert_type_t behavor, char* me
     } else if (behavor == TEST_ASSERT_AS_CLASS_EXPECT) {
         fossil_test_assert_impl_expect(expression, &_ASSERT_INFO);
     }
+    _ASSERT_INFO.num_asserts++; // increment the number of asserts
     _ASSERT_INFO.has_assert = true; // Make note of an assert being added in a given test case
 }


### PR DESCRIPTION
# Fossil Logic Layer Pull Request

## Description
Adding enhanced scanning to allow counting the number of asserts used and determining if the assertions are the same or similar using a history fingerprint.

## Changes
Add fingerprint tracking
Add a counter for the number of asserts

## Testing
The same test, just ran the test triggering some to fail to see what would happen and check the visual of the output for the test run.

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
