### PR TITLE
Remove byte string assertions

### DIFF
--- a/code/logic/fossil/test/assume.h
+++ b/code/logic/fossil/test/assume.h
@@ -2172,33 +2172,6 @@ extern "C" {
     FOSSIL_TEST_ASSUME(wcslen((actual)) == (expected_len), "Expected length of wide string " #actual " to be equal to " #expected_len)
 
 /**
- * @brief Assumes that the given byte strings are equal.
- *
- * @param actual The actual byte string.
- * @param expected The expected byte string.
- */
-#define ASSUME_ITS_EQUAL_BSTR(actual, expected) \
-    FOSSIL_TEST_ASSUME(strcmp((const char*)(actual), (const char*)(expected)) == 0, "Expected byte string " #actual " to be equal to " #expected)
-
-/**
- * @brief Assumes that the given byte strings are not equal.
- *
- * @param actual The actual byte string.
- * @param expected The expected byte string.
- */
-#define ASSUME_NOT_EQUAL_BSTR(actual, expected) \
-    FOSSIL_TEST_ASSUME(strcmp((const char*)(actual), (const char*)(expected)) != 0, "Expected byte string " #actual " to not be equal to " #expected)
-
-/**
- * @brief Assumes that the length of the given byte string is equal to the expected length.
- *
- * @param actual The actual byte string.
- * @param expected_len The expected length of the byte string.
- */
-#define ASSUME_ITS_LENGTH_EQUAL_BSTR(actual, expected_len) \
-    FOSSIL_TEST_ASSUME(strlen((const char*)(actual)) == (expected_len), "Expected length of byte string " #actual " to be equal to " #expected_len)
-
-/**
  * @brief Assumes that the given C strings are equal.
  *
  * @param actual The actual C string.

--- a/code/tests/cases/test_tdd.c
+++ b/code/tests/cases/test_tdd.c
@@ -685,17 +685,6 @@ FOSSIL_TEST_CASE(c_assume_run_of_wstr) {
     ASSUME_ITS_LENGTH_EQUAL_WSTR(str1, 5);
 } // end case
 
-FOSSIL_TEST_CASE(c_assume_run_of_bstr) {
-    const char *str1 = (const char *)"Hello";
-    const char *str2 = (const char *)"Hello";
-    const char *str3 = (const char *)"World";
-
-    // Test cases
-    ASSUME_ITS_EQUAL_BSTR(str1, str2);
-    ASSUME_NOT_EQUAL_BSTR(str1, str3);
-    ASSUME_ITS_LENGTH_EQUAL_BSTR(str1, 5);
-} // end case
-
 FOSSIL_TEST_CASE(c_assume_run_of_cstr) {
     const char *str1 = "Hello";
     const char *str2 = "Hello";
@@ -769,7 +758,6 @@ FOSSIL_TEST_GROUP(c_tdd_test_cases) {
     FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_within_range_cchar);
     FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_within_range_wchar);
     FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_wstr);
-    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_bstr);
     FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr);
 
     FOSSIL_TEST_REGISTER(c_tdd_suite);

--- a/code/tests/cases/test_tdd.cpp
+++ b/code/tests/cases/test_tdd.cpp
@@ -686,17 +686,6 @@ FOSSIL_TEST_CASE(cpp_assume_run_of_wstr) {
     ASSUME_ITS_LENGTH_EQUAL_WSTR(str1, 5);
 } // end case
 
-FOSSIL_TEST_CASE(cpp_assume_run_of_bstr) {
-    std::string str1 = "Hello";
-    std::string str2 = "Hello";
-    std::string str3 = "World";
-
-    // Test cases
-    ASSUME_ITS_EQUAL_BSTR(str1.c_str(), str2.c_str());
-    ASSUME_NOT_EQUAL_BSTR(str1.c_str(), str3.c_str());
-    ASSUME_ITS_LENGTH_EQUAL_BSTR(str1.c_str(), 5);
-} // end case
-
 FOSSIL_TEST_CASE(cpp_assume_run_of_cstr) {
     std::string str1 = "Hello";
     std::string str2 = "Hello";
@@ -770,7 +759,6 @@ FOSSIL_TEST_GROUP(cpp_tdd_test_cases) {
     FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_within_range_cchar);
     FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_within_range_wchar);
     FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_wstr);
-    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_bstr);
     FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr);
 
     FOSSIL_TEST_REGISTER(cpp_tdd_suite);


### PR DESCRIPTION
# Fossil Logic Layer Pull Request

## Description
In the interest of simplifying the assertion string list byte strings will be removed due to extra trouble and cost to manage

## Testing
Same test but no byte string assertions in site

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
