### PR TITLE
Adding Test & Apply Change to Assume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ***Fossil Test by Fossil Logic***
+# ***Pizza Test by Pizza Logic***
 
-**Fossil Test** is a comprehensive suite for unit testing, mocking, and benchmarking, designed by Fossil Logic to enhance the reliability, clarity, and performance of **C**, **C++**, and **Python** projects. Supporting methodologies like Behavior-Driven Development (BDD), Domain-Driven Design (DDD), and Test-Driven Development (TDD), it caters to diverse workflows with features such as a robust Command-Line Interface (CLI), advanced mocking tools, integrated benchmarking, and parallel test execution. With additional capabilities like customizable output themes, tag-based test filtering, and detailed performance insights, **Fossil Test**, alongside **Fossil Mock**, **Fossil Mark**, and **Fossil Sanity Kit** for testing command-line operations, forms a powerful toolkit for building, testing, and optimizing high-quality, maintainable software.
+**Pizza Test** is a comprehensive suite for unit testing, mocking, and benchmarking, designed by Pizza Logic to enhance the reliability, clarity, and performance of **C** and **C++** projects. Supporting methodologies like Behavior-Driven Development (BDD), Domain-Driven Design (DDD), and Test-Driven Development (TDD), it caters to diverse workflows with features such as a robust Command-Line Interface (CLI), advanced mocking tools, integrated benchmarking, and parallel test execution. With additional capabilities like customizable output themes, tag-based test filtering, and detailed performance insights, **Pizza Test**, alongside **Pizza Mock**, **Pizza Mark**, and **Pizza Sanity Kit** for testing command-line operations, forms a powerful toolkit for building, testing, and optimizing high-quality, maintainable software.
 
 | Feature                     | Description                                                                                                                             |
 |-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
@@ -9,7 +9,7 @@
 | **Mocking Capabilities** | Advanced mocking tools to simulate complex dependencies, ensuring isolated and precise unit testing. |
 | **Benchmarking Tools** | Integrated benchmarking features to measure execution time, identify bottlenecks, and optimize code performance. |
 | **Sanity Kit for Command Tests** | A specialized suite for validating command-line tools and scripts, ensuring consistent behavior across environments. |
-| **Customizable Output Themes** | Multiple output themes (e.g., fossil, catch, doctest) to tailor the appearance of test results. |
+| **Customizable Output Themes** | Multiple output themes (e.g., pizza, catch, doctest) to tailor the appearance of test results. |
 | **Tag-Based Test Filtering** | Organize and execute tests based on custom tags for better test management. |
 | **Detailed Performance Insights** | Comprehensive reporting on test execution times and resource usage to aid in performance optimization. |
 
@@ -17,15 +17,15 @@
 
 ## ***Prerequisites***
 
-To get started with Fossil Test, ensure you have the following installed:
+To get started with Pizza Test, ensure you have the following installed:
 
 - **Meson Build System**: If you don’t have Meson installed, follow the installation instructions on the official [Meson website](https://mesonbuild.com/Getting-meson.html).
 
 ---
 
-### Adding Fossil Test Dependency
+### Adding Pizza Test Dependency
 
-#### Adding Fossil Test Dependency With Meson
+#### Adding Pizza Test Dependency With Meson
 
 1. **Install Meson Build System**:
    Install Meson version `1.3` or newer:
@@ -35,14 +35,14 @@ To get started with Fossil Test, ensure you have the following installed:
    ```
 
 2. **Create a `.wrap` File**:
-   Add the `fossil-test.wrap` file in your `subprojects` directory and include the following content:
+   Add a `fossil-test.wrap` file in your `subprojects` directory with the following content:
 
    ```ini
    # ======================
    # Git Wrap package definition
    # ======================
    [wrap-git]
-   url = https://github.com/fossillogic/fossil-test.git
+   url = https://github.com/pizzalogic/fossil-test.git
    revision = v1.2.1
 
    [provide]
@@ -51,23 +51,23 @@ To get started with Fossil Test, ensure you have the following installed:
 
 3. **Integrate the Dependency**:
    In your `meson.build` file, integrate Fossil Test by adding the following line:
-   ```ini
+   ```meson
    dep = dependency('fossil-test')
    ```
 
 ---
 
-**Note**: For the best experience, always use the latest release of Fossil Test. Visit the [Fossil Test Releases](https://github.com/fossillogic/fossil-test/releases) page for the latest versions.
+**Note**: For the best experience, always use the latest release of Pizza Test. Visit the [Pizza Test Releases](https://github.com/pizzalogic/pizza-test/releases) page for the latest versions.
 
-## Fossil Test CLI Usage
+## Pizza Test CLI Usage
 
-The Fossil Test CLI provides an efficient way to run and manage tests directly from the terminal. Here are the available commands and options:
+The Pizza Test CLI provides an efficient way to run and manage tests directly from the terminal. Here are the available commands and options:
 
 ### Commands and Options
 
 | Command                          | Description                                                                                   | Notes                                                                                         |
 |----------------------------------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------|
-| `--version`                      | Displays the current version of Fossil Test.                                                  | Useful for verifying the version of the tool in use.                                          |
+| `--version`                      | Displays the current version of Pizza Test.                                                  | Useful for verifying the version of the tool in use.                                          |
 | `--help`                         | Shows help message with usage instructions.                                                   | Provides a quick reference for all available commands.                                        |
 | `--dry-run`                      | Perform a dry run without executing commands.                                                 | Ideal for verifying test selection criteria before actual execution.                          |
 | `--host`                         | Shows info about the current host system.                                                     | Useful for looking up system you are running test on.                                          |
@@ -76,7 +76,7 @@ The Fossil Test CLI provides an efficient way to run and manage tests directly f
 | `sort`                           | Sort tests by specified criteria.                                                             | Allows sorting in ascending or descending order.                                              |
 | `shuffle`                        | Shuffle tests with optional parameters.                                                       | Includes options for specifying a seed or shuffle criteria.                                   |
 | `color=<mode>`                   | Set color mode (enable, disable, auto).                                                       | Enhances readability in supported terminals.                                                  |
-| `theme=<name>`                   | Set the theme (fossil, catch, doctest, etc.).                                                 | Customizes the appearance of test output.                                                     |
+| `theme=<name>`                   | Set the theme (pizza, catch, doctest, etc.).                                                 | Customizes the appearance of test output.                                                     |
 | `verbose=<level>`                | Set verbosity level (plain, ci, doge).                                                        | Adjusts the level of detail in test output.                                                   |
 
 ### Run Command Options
@@ -122,10 +122,10 @@ meson setup builddir -Dwith_test=enabled
 
 ## ***Contributing and Support***
 
-If you would like to contribute, have questions, or need help, feel free to open an issue on the [Fossil Test GitHub repository](https://github.com/fossillogic/fossil-test) or consult the [Fossil Logic Docs](https://fossillogic.com/docs).
+If you would like to contribute, have questions, or need help, feel free
 
 ---
 
 ## ***Conclusion***
 
-Fossil Test is a powerful and flexible framework for C and C++ developers, designed to support a wide range of testing methodologies such as BDD, DDD, and TDD. With features like mocking, detailed reporting, and performance tracking, Fossil Test empowers developers to create high-quality software and maintainable test suites. Combined with Fossil Mark and Fossil Mock, it provides a complete suite for testing, optimization, and dependency management. Whether you're building small projects or large-scale applications, Fossil Test is an essential tool to ensure the reliability and performance of your code.
+Pizza Test is a powerful and flexible framework for C and C++ developers, designed to support a wide range of testing methodologies such as BDD, DDD, and TDD. With features like mocking, detailed reporting, and performance tracking, Pizza Test empowers developers to create high-quality software and maintainable test suites. Combined with Pizza Mark and Pizza Mock, it provides a complete suite for testing, optimization, and dependency management. Whether you're building small projects or large-scale applications, Pizza Test is an essential tool to ensure the reliability and performance of your code.

--- a/code/logic/common.c
+++ b/code/logic/common.c
@@ -1223,6 +1223,28 @@ void pizza_io_printf(const char *format, ...) {
     va_end(args);
 }
 
+int pizza_io_vsnprintf(char *buffer, size_t size, const char *format, va_list args) {
+    if (buffer == null || size == 0 || format == null) {
+        return -1; // Invalid input
+    }
+
+    // Create a temporary buffer to hold the formatted string
+    char temp_buffer[FOSSIL_IO_BUFFER_SIZE];
+    int formatted_length = vsnprintf(temp_buffer, sizeof(temp_buffer), format, args);
+
+    if (formatted_length < 0 || (size_t)formatted_length >= size) {
+        // Truncate the string if it exceeds the provided buffer size
+        strncpy(buffer, temp_buffer, size - 1);
+        buffer[size - 1] = '\0'; // Ensure null termination
+        return (formatted_length < 0) ? -1 : (int)(size - 1);
+    }
+
+    // Copy the formatted string to the provided buffer
+    strncpy(buffer, temp_buffer, size);
+    buffer[formatted_length] = '\0'; // Ensure null termination
+    return formatted_length;
+}
+
 // Function to print a sanitized string to a specific file stream
 void pizza_io_fputs(pizza_fstream_t *stream, const char *str) {
     if (str != null && stream != null) {

--- a/code/logic/common.c
+++ b/code/logic/common.c
@@ -916,13 +916,18 @@ pizza_sys_memory_t pizza_sys_memory_dup(const pizza_sys_memory_t src, size_t siz
     return memcpy(dest, src, size);
 }
 
-void pizza_sys_memory_zero(pizza_sys_memory_t ptr, size_t size) {
-    if (!ptr || size == 0) {
-        fprintf(stderr, "Error: pizza_sys_memory_zero() - Invalid pointer or zero size.\n");
-        return;
+pizza_sys_memory_t pizza_sys_memory_zero(pizza_sys_memory_t ptr, size_t size) {
+    if (!ptr) {
+        fprintf(stderr, "Error: pizza_sys_memory_zero() - Pointer is null.\n");
+        return null;
     }
-    
-    memset(ptr, 0, size);
+
+    if (size == 0) {
+        fprintf(stderr, "Error: pizza_sys_memory_zero() - Cannot zero out zero bytes.\n");
+        return null;
+    }
+
+    return memset(ptr, 0, size);
 }
 
 int pizza_sys_memory_compare(const pizza_sys_memory_t ptr1, const pizza_sys_memory_t ptr2, size_t size) {

--- a/code/logic/fossil/pizza/assume.h
+++ b/code/logic/fossil/pizza/assume.h
@@ -44,7 +44,7 @@ extern "C" {
  * @param actual The boolean expression to be evaluated.
  */
 #define ASSUME_ITS_TRUE(actual) \
-    FOSSIL_TEST_ASSUME((actual), "Expected " #actual " to be true")
+    FOSSIL_TEST_ASSUME((actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %s to be true", (actual) ? "true" : "false"))
 
 /**
  * @brief Assumes that the given boolean expression is false.
@@ -52,7 +52,7 @@ extern "C" {
  * @param actual The boolean expression to be evaluated.
  */
 #define ASSUME_ITS_FALSE(actual) \
-    FOSSIL_TEST_ASSUME(!(actual), "Expected " #actual " to be false")
+    FOSSIL_TEST_ASSUME(!(actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %s to be false", (actual) ? "true" : "false"))
 
 /**
  * @brief Assumes that the given boolean expression is not true.
@@ -60,7 +60,7 @@ extern "C" {
  * @param actual The boolean expression to be evaluated.
  */
 #define ASSUME_NOT_TRUE(actual) \
-    FOSSIL_TEST_ASSUME(!(actual), "Expected " #actual " to not be true")
+    FOSSIL_TEST_ASSUME(!(actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %s to not be true", (actual) ? "true" : "false"))
 
 /**
  * @brief Assumes that the given boolean expression is not false.
@@ -68,7 +68,7 @@ extern "C" {
  * @param actual The boolean expression to be evaluated.
  */
 #define ASSUME_NOT_FALSE(actual) \
-    FOSSIL_TEST_ASSUME((actual), "Expected " #actual " to not be false")
+    FOSSIL_TEST_ASSUME((actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %s to not be false", (actual) ? "true" : "false"))
 
 // **************************************************
 //
@@ -85,7 +85,7 @@ extern "C" {
  * @param tol The tolerance within which the values should be considered equal.
  */
 #define ASSUME_ITS_EQUAL_F64(actual, expected, tol) \
-    FOSSIL_TEST_ASSUME(fabs((actual) - (expected)) <= (tol), "Expected " #actual " to be equal to " #expected " within tolerance " #tol)
+    FOSSIL_TEST_ASSUME(fabs((actual) - (expected)) <= (tol), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be equal to " #expected " of value %f within tolerance " #tol " of value %f", (actual), (expected), (tol)))
 
 /**
  * @brief Assumes that the given double value is less than the expected value.
@@ -94,7 +94,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_ITS_LESS_THAN_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) < (expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((actual) < (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be less than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given double value is more than the expected value.
@@ -103,7 +103,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_ITS_MORE_THAN_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) > (expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((actual) > (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be more than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given double value is less than or equal to the expected value.
@@ -112,7 +112,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) <= (expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) <= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be less than or equal to " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given double value is more than or equal to the expected value.
@@ -121,7 +121,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) >= (expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) >= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be more than or equal to " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given double values are not equal within a specified tolerance.
@@ -131,7 +131,7 @@ extern "C" {
  * @param tol The tolerance within which the values should not be considered equal.
  */
 #define ASSUME_NOT_EQUAL_F64(actual, expected, tol) \
-    FOSSIL_TEST_ASSUME(fabs((actual) - (expected)) > (tol), "Expected " #actual " to not be equal to " #expected " within tolerance " #tol)
+    FOSSIL_TEST_ASSUME(fabs((actual) - (expected)) > (tol), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be equal to " #expected " of value %f within tolerance " #tol " of value %f", (actual), (expected), (tol)))
 
 /**
  * @brief Assumes that the given double value is not less than the expected value.
@@ -140,7 +140,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_NOT_LESS_THAN_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) >= (expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((actual) >= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be less than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given double value is not more than the expected value.
@@ -149,7 +149,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_NOT_MORE_THAN_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) <= (expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((actual) <= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be more than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given double value is not less than or equal to the expected value.
@@ -158,7 +158,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) > (expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) > (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be less than or equal to " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given double value is not more than or equal to the expected value.
@@ -167,7 +167,7 @@ extern "C" {
  * @param expected The expected double value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_F64(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) < (expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) < (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be more than or equal to " #expected " of value %f", (actual), (expected)))
 
 // Float equality check with tolerance
 /**
@@ -178,7 +178,7 @@ extern "C" {
  * @param tol The tolerance within which the values should be considered equal.
  */
 #define ASSUME_ITS_EQUAL_F32(actual, expected, tol) \
-    FOSSIL_TEST_ASSUME(fabsf((actual) - (expected)) <= (tol), "Expected " #actual " to be equal to " #expected " within tolerance " #tol)
+    FOSSIL_TEST_ASSUME(fabsf((actual) - (expected)) <= (tol), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be equal to " #expected " of value %f within tolerance " #tol " of value %f", (actual), (expected), (tol)))
 
 /**
  * @brief Assumes that the given float value is less than the expected value.
@@ -187,7 +187,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_ITS_LESS_THAN_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) < (expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((actual) < (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be less than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given float value is more than the expected value.
@@ -196,7 +196,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_ITS_MORE_THAN_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) > (expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((actual) > (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be more than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given float value is less than or equal to the expected value.
@@ -205,7 +205,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) <= (expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) <= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be less than or equal to " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given float value is more than or equal to the expected value.
@@ -214,7 +214,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) >= (expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) >= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be more than or equal to " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given float values are not equal within a specified tolerance.
@@ -224,7 +224,7 @@ extern "C" {
  * @param tol The tolerance within which the values should not be considered equal.
  */
 #define ASSUME_NOT_EQUAL_F32(actual, expected, tol) \
-    FOSSIL_TEST_ASSUME(fabsf((actual) - (expected)) > (tol), "Expected " #actual " to not be equal to " #expected " within tolerance " #tol)
+    FOSSIL_TEST_ASSUME(fabsf((actual) - (expected)) > (tol), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be equal to " #expected " of value %f within tolerance " #tol " of value %f", (actual), (expected), (tol)))
 
 /**
  * @brief Assumes that the given float value is not less than the expected value.
@@ -233,7 +233,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_NOT_LESS_THAN_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) >= (expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((actual) >= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be less than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given float value is not more than the expected value.
@@ -242,7 +242,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_NOT_MORE_THAN_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) <= (expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((actual) <= (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be more than " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given float value is not less than or equal to the expected value.
@@ -251,7 +251,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) > (expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) > (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be less than or equal to " #expected " of value %f", (actual), (expected)))
 
 /**
  * @brief Assumes that the given float value is not more than or equal to the expected value.
@@ -260,7 +260,7 @@ extern "C" {
  * @param expected The expected float value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_F32(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) < (expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((actual) < (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to not be more than or equal to " #expected " of value %f", (actual), (expected)))
 
 // Float NaN and Infinity checks
 /**
@@ -269,7 +269,7 @@ extern "C" {
  * @param actual The actual float value.
  */
 #define ASSUME_ITS_NAN_F32(actual) \
-    FOSSIL_TEST_ASSUME(isnan(actual), "Expected " #actual " to be NaN")
+    FOSSIL_TEST_ASSUME(isnan(actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be NaN", (actual)))
 
 /**
  * @brief Assumes that the given float value is infinity.
@@ -277,7 +277,7 @@ extern "C" {
  * @param actual The actual float value.
  */
 #define ASSUME_ITS_INF_F32(actual) \
-    FOSSIL_TEST_ASSUME(isinf(actual), "Expected " #actual " to be infinity")
+    FOSSIL_TEST_ASSUME(isinf(actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be infinity", (actual)))
 
 // Double NaN and Infinity checks
 /**
@@ -286,7 +286,7 @@ extern "C" {
  * @param actual The actual double value.
  */
 #define ASSUME_ITS_NAN_F64(actual) \
-    FOSSIL_TEST_ASSUME(isnan(actual), "Expected " #actual " to be NaN")
+    FOSSIL_TEST_ASSUME(isnan(actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be NaN", (actual)))
 
 /**
  * @brief Assumes that the given double value is infinity.
@@ -294,7 +294,7 @@ extern "C" {
  * @param actual The actual double value.
  */
 #define ASSUME_ITS_INF_F64(actual) \
-    FOSSIL_TEST_ASSUME(isinf(actual), "Expected " #actual " to be infinity")
+    FOSSIL_TEST_ASSUME(isinf(actual), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %f to be infinity", (actual)))
 
 // **************************************************
 //
@@ -309,7 +309,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_ITS_EQUAL_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) == (uint8_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) == (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is less than the expected value.
@@ -318,7 +318,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_ITS_LESS_THAN_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is more than the expected value.
@@ -327,7 +327,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_ITS_MORE_THAN_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is less than or equal to the expected value.
@@ -336,7 +336,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is more than or equal to the expected value.
@@ -345,7 +345,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal values are not equal.
@@ -354,7 +354,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_NOT_EQUAL_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) != (uint8_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) != (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is not less than the expected value.
@@ -363,7 +363,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_NOT_LESS_THAN_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is not more than the expected value.
@@ -372,7 +372,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_NOT_MORE_THAN_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is not less than or equal to the expected value.
@@ -381,7 +381,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit octal value is not more than or equal to the expected value.
@@ -390,7 +390,7 @@ extern "C" {
  * @param expected The expected 8-bit octal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_O8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal values are equal.
@@ -399,7 +399,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_ITS_EQUAL_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) == (uint16_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) == (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is less than the expected value.
@@ -408,7 +408,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_ITS_LESS_THAN_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is more than the expected value.
@@ -417,7 +417,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_ITS_MORE_THAN_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is less than or equal to the expected value.
@@ -426,7 +426,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is more than or equal to the expected value.
@@ -435,7 +435,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal values are not equal.
@@ -444,7 +444,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_NOT_EQUAL_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) != (uint16_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) != (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is not less than the expected value.
@@ -453,7 +453,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_NOT_LESS_THAN_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is not more than the expected value.
@@ -462,7 +462,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_NOT_MORE_THAN_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is not less than or equal to the expected value.
@@ -471,7 +471,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit octal value is not more than or equal to the expected value.
@@ -480,7 +480,7 @@ extern "C" {
  * @param expected The expected 16-bit octal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_O16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal values are equal.
@@ -489,7 +489,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_ITS_EQUAL_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) == (uint32_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) == (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is less than the expected value.
@@ -498,7 +498,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_ITS_LESS_THAN_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is more than the expected value.
@@ -507,7 +507,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_ITS_MORE_THAN_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is less than or equal to the expected value.
@@ -516,7 +516,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is more than or equal to the expected value.
@@ -525,7 +525,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal values are not equal.
@@ -534,7 +534,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_NOT_EQUAL_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) != (uint32_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) != (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is not less than the expected value.
@@ -543,7 +543,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_NOT_LESS_THAN_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is not more than the expected value.
@@ -552,7 +552,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_NOT_MORE_THAN_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is not less than or equal to the expected value.
@@ -561,7 +561,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit octal value is not more than or equal to the expected value.
@@ -570,7 +570,7 @@ extern "C" {
  * @param expected The expected 32-bit octal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_O32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal values are equal.
@@ -579,7 +579,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_ITS_EQUAL_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) == (uint64_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) == (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is less than the expected value.
@@ -588,7 +588,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_ITS_LESS_THAN_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be less than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is more than the expected value.
@@ -597,7 +597,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_ITS_MORE_THAN_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be more than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is less than or equal to the expected value.
@@ -606,7 +606,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be less than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is more than or equal to the expected value.
@@ -615,7 +615,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be more than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal values are not equal.
@@ -624,7 +624,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_NOT_EQUAL_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) != (uint64_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) != (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is not less than the expected value.
@@ -633,7 +633,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_NOT_LESS_THAN_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be less than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is not more than the expected value.
@@ -642,7 +642,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_NOT_MORE_THAN_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be more than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is not less than or equal to the expected value.
@@ -651,7 +651,7 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be less than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit octal value is not more than or equal to the expected value.
@@ -660,9 +660,9 @@ extern "C" {
  * @param expected The expected 64-bit octal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_O64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be more than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
-// Hexadecimal assumtions
+// Hexadecimal assumptions
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal values are equal.
@@ -671,7 +671,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_ITS_EQUAL_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) == (uint8_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) == (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is less than the expected value.
@@ -680,7 +680,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_THAN_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is more than the expected value.
@@ -689,7 +689,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_THAN_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is less than or equal to the expected value.
@@ -698,7 +698,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is more than or equal to the expected value.
@@ -707,7 +707,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal values are not equal.
@@ -716,7 +716,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_NOT_EQUAL_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) != (uint8_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) != (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is not less than the expected value.
@@ -725,7 +725,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_THAN_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is not more than the expected value.
@@ -734,7 +734,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_THAN_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is not less than or equal to the expected value.
@@ -743,7 +743,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit hexadecimal value is not more than or equal to the expected value.
@@ -752,7 +752,7 @@ extern "C" {
  * @param expected The expected 8-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_H8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal values are equal.
@@ -761,7 +761,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_ITS_EQUAL_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) == (uint16_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) == (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is less than the expected value.
@@ -770,7 +770,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_THAN_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is more than the expected value.
@@ -779,7 +779,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_THAN_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is less than or equal to the expected value.
@@ -788,7 +788,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is more than or equal to the expected value.
@@ -797,7 +797,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal values are not equal.
@@ -806,7 +806,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_NOT_EQUAL_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) != (uint16_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) != (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is not less than the expected value.
@@ -815,7 +815,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_THAN_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is not more than the expected value.
@@ -824,7 +824,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_THAN_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is not less than or equal to the expected value.
@@ -833,7 +833,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit hexadecimal value is not more than or equal to the expected value.
@@ -842,7 +842,7 @@ extern "C" {
  * @param expected The expected 16-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_H16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal values are equal.
@@ -851,7 +851,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_ITS_EQUAL_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) == (uint32_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) == (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is less than the expected value.
@@ -860,7 +860,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_THAN_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is more than the expected value.
@@ -869,7 +869,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_THAN_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is less than or equal to the expected value.
@@ -878,7 +878,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is more than or equal to the expected value.
@@ -887,7 +887,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal values are not equal.
@@ -896,7 +896,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_NOT_EQUAL_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) != (uint32_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) != (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is not less than the expected value.
@@ -905,7 +905,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_THAN_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is not more than the expected value.
@@ -914,7 +914,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_THAN_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is not less than or equal to the expected value.
@@ -923,7 +923,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit hexadecimal value is not more than or equal to the expected value.
@@ -932,7 +932,7 @@ extern "C" {
  * @param expected The expected 32-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_H32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal values are equal.
@@ -941,7 +941,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_ITS_EQUAL_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) == (uint64_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) == (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is less than the expected value.
@@ -950,7 +950,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_THAN_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be less than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is more than the expected value.
@@ -959,7 +959,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_THAN_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be more than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is less than or equal to the expected value.
@@ -968,7 +968,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be less than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is more than or equal to the expected value.
@@ -977,7 +977,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be more than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal values are not equal.
@@ -986,7 +986,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_NOT_EQUAL_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) != (uint64_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) != (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is not less than the expected value.
@@ -995,7 +995,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_THAN_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be less than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is not more than the expected value.
@@ -1004,7 +1004,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_THAN_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be more than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is not less than or equal to the expected value.
@@ -1013,7 +1013,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be less than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit hexadecimal value is not more than or equal to the expected value.
@@ -1022,7 +1022,7 @@ extern "C" {
  * @param expected The expected 64-bit hexadecimal value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_H64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be more than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer values are equal.
@@ -1031,7 +1031,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_ITS_EQUAL_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) == (int8_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) == (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be equal to " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is less than the expected value.
@@ -1040,7 +1040,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_ITS_LESS_THAN_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) < (int8_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) < (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be less than " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is more than the expected value.
@@ -1049,7 +1049,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_ITS_MORE_THAN_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) > (int8_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) > (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be more than " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is less than or equal to the expected value.
@@ -1058,7 +1058,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) <= (int8_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) <= (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be less than or equal to " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is more than or equal to the expected value.
@@ -1067,7 +1067,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) >= (int8_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) >= (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be more than or equal to " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer values are not equal.
@@ -1076,7 +1076,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_NOT_EQUAL_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) != (int8_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) != (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be equal to " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is not less than the expected value.
@@ -1085,7 +1085,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_NOT_LESS_THAN_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) >= (int8_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) >= (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be less than " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is not more than the expected value.
@@ -1094,7 +1094,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_NOT_MORE_THAN_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) <= (int8_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) <= (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be more than " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is not less than or equal to the expected value.
@@ -1103,7 +1103,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) > (int8_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) > (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be less than or equal to " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is not more than or equal to the expected value.
@@ -1112,7 +1112,7 @@ extern "C" {
  * @param expected The expected 8-bit integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_I8(actual, expected) \
-    FOSSIL_TEST_ASSUME((int8_t)(actual) < (int8_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int8_t)(actual) < (int8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be more than or equal to " #expected " of value %d", (int8_t)(actual), (int8_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer values are equal.
@@ -1121,7 +1121,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_ITS_EQUAL_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) == (int16_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) == (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be equal to " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is less than the expected value.
@@ -1130,7 +1130,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_ITS_LESS_THAN_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) < (int16_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) < (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be less than " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is more than the expected value.
@@ -1139,7 +1139,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_ITS_MORE_THAN_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) > (int16_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) > (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be more than " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is less than or equal to the expected value.
@@ -1148,7 +1148,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) <= (int16_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) <= (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be less than or equal to " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is more than or equal to the expected value.
@@ -1157,7 +1157,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) >= (int16_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) >= (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be more than or equal to " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer values are not equal.
@@ -1166,7 +1166,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_NOT_EQUAL_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) != (int16_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) != (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be equal to " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is not less than the expected value.
@@ -1175,7 +1175,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_NOT_LESS_THAN_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) >= (int16_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) >= (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be less than " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is not more than the expected value.
@@ -1184,7 +1184,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_NOT_MORE_THAN_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) <= (int16_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) <= (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be more than " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is not less than or equal to the expected value.
@@ -1193,7 +1193,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) > (int16_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) > (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be less than or equal to " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is not more than or equal to the expected value.
@@ -1202,7 +1202,7 @@ extern "C" {
  * @param expected The expected 16-bit integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_I16(actual, expected) \
-    FOSSIL_TEST_ASSUME((int16_t)(actual) < (int16_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int16_t)(actual) < (int16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be more than or equal to " #expected " of value %d", (int16_t)(actual), (int16_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer values are equal.
@@ -1211,7 +1211,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_ITS_EQUAL_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) == (int32_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) == (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be equal to " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is less than the expected value.
@@ -1220,7 +1220,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_ITS_LESS_THAN_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) < (int32_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) < (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be less than " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is more than the expected value.
@@ -1229,7 +1229,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_ITS_MORE_THAN_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) > (int32_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) > (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be more than " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is less than or equal to the expected value.
@@ -1238,7 +1238,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) <= (int32_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) <= (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be less than or equal to " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is more than or equal to the expected value.
@@ -1247,7 +1247,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) >= (int32_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) >= (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to be more than or equal to " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer values are not equal.
@@ -1256,7 +1256,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_NOT_EQUAL_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) != (int32_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) != (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be equal to " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is not less than the expected value.
@@ -1265,7 +1265,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_NOT_LESS_THAN_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) >= (int32_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) >= (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be less than " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is not more than the expected value.
@@ -1274,7 +1274,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_NOT_MORE_THAN_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) <= (int32_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) <= (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be more than " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is not less than or equal to the expected value.
@@ -1283,7 +1283,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) > (int32_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) > (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be less than or equal to " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is not more than or equal to the expected value.
@@ -1292,7 +1292,7 @@ extern "C" {
  * @param expected The expected 32-bit integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_I32(actual, expected) \
-    FOSSIL_TEST_ASSUME((int32_t)(actual) < (int32_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int32_t)(actual) < (int32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %d to not be more than or equal to " #expected " of value %d", (int32_t)(actual), (int32_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer values are equal.
@@ -1301,7 +1301,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_ITS_EQUAL_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) == (int64_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) == (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to be equal to " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is less than the expected value.
@@ -1310,7 +1310,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_ITS_LESS_THAN_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) < (int64_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) < (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to be less than " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is more than the expected value.
@@ -1319,7 +1319,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_ITS_MORE_THAN_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) > (int64_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) > (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to be more than " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is less than or equal to the expected value.
@@ -1328,7 +1328,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) <= (int64_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) <= (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to be less than or equal to " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is more than or equal to the expected value.
@@ -1337,7 +1337,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) >= (int64_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) >= (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to be more than or equal to " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer values are not equal.
@@ -1346,7 +1346,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_NOT_EQUAL_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) != (int64_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) != (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to not be equal to " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is not less than the expected value.
@@ -1355,7 +1355,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_NOT_LESS_THAN_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) >= (int64_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) >= (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to not be less than " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is not more than the expected value.
@@ -1364,7 +1364,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_NOT_MORE_THAN_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) <= (int64_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) <= (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to not be more than " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is not less than or equal to the expected value.
@@ -1373,7 +1373,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) > (int64_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) > (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to not be less than or equal to " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is not more than or equal to the expected value.
@@ -1382,7 +1382,7 @@ extern "C" {
  * @param expected The expected 64-bit integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_I64(actual, expected) \
-    FOSSIL_TEST_ASSUME((int64_t)(actual) < (int64_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((int64_t)(actual) < (int64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %lld to not be more than or equal to " #expected " of value %lld", (int64_t)(actual), (int64_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer values are equal.
@@ -1391,7 +1391,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_ITS_EQUAL_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) == (uint8_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) == (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is less than the expected value.
@@ -1400,7 +1400,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_THAN_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is more than the expected value.
@@ -1409,7 +1409,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_THAN_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is less than or equal to the expected value.
@@ -1418,7 +1418,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is more than or equal to the expected value.
@@ -1427,7 +1427,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer values are not equal.
@@ -1436,7 +1436,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_NOT_EQUAL_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) != (uint8_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) != (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is not less than the expected value.
@@ -1445,7 +1445,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_THAN_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) >= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is not more than the expected value.
@@ -1454,7 +1454,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_THAN_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) <= (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is not less than or equal to the expected value.
@@ -1463,7 +1463,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) > (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is not more than or equal to the expected value.
@@ -1472,7 +1472,7 @@ extern "C" {
  * @param expected The expected 8-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_U8(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint8_t)(actual) < (uint8_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint8_t)(actual), (uint8_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer values are equal.
@@ -1481,7 +1481,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_ITS_EQUAL_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) == (uint16_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) == (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is less than the expected value.
@@ -1490,7 +1490,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_THAN_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is more than the expected value.
@@ -1499,7 +1499,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_THAN_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is less than or equal to the expected value.
@@ -1508,7 +1508,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is more than or equal to the expected value.
@@ -1517,7 +1517,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer values are not equal.
@@ -1526,7 +1526,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_NOT_EQUAL_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) != (uint16_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) != (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is not less than the expected value.
@@ -1535,7 +1535,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_THAN_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) >= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is not more than the expected value.
@@ -1544,7 +1544,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_THAN_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) <= (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is not less than or equal to the expected value.
@@ -1553,7 +1553,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) > (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is not more than or equal to the expected value.
@@ -1562,7 +1562,7 @@ extern "C" {
  * @param expected The expected 16-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_U16(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint16_t)(actual) < (uint16_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint16_t)(actual), (uint16_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer values are equal.
@@ -1571,7 +1571,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_ITS_EQUAL_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) == (uint32_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) == (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is less than the expected value.
@@ -1580,7 +1580,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_THAN_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is more than the expected value.
@@ -1589,7 +1589,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_THAN_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is less than or equal to the expected value.
@@ -1598,7 +1598,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be less than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is more than or equal to the expected value.
@@ -1607,7 +1607,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to be more than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer values are not equal.
@@ -1616,7 +1616,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_NOT_EQUAL_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) != (uint32_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) != (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is not less than the expected value.
@@ -1625,7 +1625,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_THAN_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) >= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is not more than the expected value.
@@ -1634,7 +1634,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_THAN_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) <= (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is not less than or equal to the expected value.
@@ -1643,7 +1643,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) > (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be less than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is not more than or equal to the expected value.
@@ -1652,7 +1652,7 @@ extern "C" {
  * @param expected The expected 32-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_U32(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint32_t)(actual) < (uint32_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %u to not be more than or equal to " #expected " of value %u", (uint32_t)(actual), (uint32_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer values are equal.
@@ -1661,7 +1661,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_ITS_EQUAL_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) == (uint64_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) == (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is less than the expected value.
@@ -1670,7 +1670,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_THAN_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be less than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is more than the expected value.
@@ -1679,7 +1679,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_THAN_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be more than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is less than or equal to the expected value.
@@ -1688,7 +1688,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be less than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is more than or equal to the expected value.
@@ -1697,7 +1697,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to be more than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer values are not equal.
@@ -1706,7 +1706,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_NOT_EQUAL_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) != (uint64_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) != (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is not less than the expected value.
@@ -1715,7 +1715,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_THAN_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), "Expected " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) >= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be less than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is not more than the expected value.
@@ -1724,7 +1724,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_THAN_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), "Expected " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) <= (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be more than " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is not less than or equal to the expected value.
@@ -1733,7 +1733,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), "Expected " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) > (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be less than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is not more than or equal to the expected value.
@@ -1742,7 +1742,7 @@ extern "C" {
  * @param expected The expected 64-bit unsigned integer value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_U64(actual, expected) \
-    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), "Expected " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((uint64_t)(actual) < (uint64_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %llu to not be more than or equal to " #expected " of value %llu", (uint64_t)(actual), (uint64_t)(expected)))
 
 // **************************************************
 //
@@ -1757,7 +1757,7 @@ extern "C" {
  * @param size The size of the memory to check.
  */
 #define ASSUME_ITS_ZERO_MEMORY(ptr, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_zero((ptr), (size)), "Expected memory at " #ptr " to be zeroed")
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_zero((ptr), (size)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory at " #ptr " of size %zu to be zeroed", (size)))
 
 /**
  * @brief Assumes that the given memory is not zeroed.
@@ -1766,7 +1766,7 @@ extern "C" {
  * @param size The size of the memory to check.
  */
 #define ASSUME_NOT_ZERO_MEMORY(ptr, size) \
-    FOSSIL_TEST_ASSUME(!pizza_sys_memory_zero((ptr), (size)), "Expected memory at " #ptr " to not be zero")
+    FOSSIL_TEST_ASSUME(!pizza_sys_memory_zero((ptr), (size)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory at " #ptr " of size %zu to not be zeroed", (size)))
 
 /**
  * @brief Assumes that the given memory regions are equal.
@@ -1776,7 +1776,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_ITS_EQUAL_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) == 0, "Expected memory regions " #ptr1 " and " #ptr2 " to be equal")
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) == 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory regions " #ptr1 " and " #ptr2 " of size %zu to be equal", (size)))
 
 /**
  * @brief Assumes that the given memory regions are not equal.
@@ -1785,8 +1785,8 @@ extern "C" {
  * @param ptr2 A pointer to the second memory region.
  * @param size The size of the memory regions to compare.
  */
-#define ASSUME_ITS_NOT_EQUAL_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) != 0, "Expected memory regions " #ptr1 " and " #ptr2 " to not be equal")
+#define ASSUME_NOT_EQUAL_MEMORY(ptr1, ptr2, size) \
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) != 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory regions " #ptr1 " and " #ptr2 " of size %zu to not be equal", (size)))
 
 /**
  * @brief Assumes that the given memory region is more than the expected memory region.
@@ -1796,7 +1796,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_ITS_MORE_THAN_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) > 0, "Expected memory region " #ptr1 " to be more than " #ptr2)
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) > 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to be more than " #ptr2 " for size %zu", (size)))
 
 /**
  * @brief Assumes that the given memory region is less than the expected memory region.
@@ -1806,7 +1806,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_ITS_LESS_THAN_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) < 0, "Expected memory region " #ptr1 " to be less than " #ptr2)
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) < 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to be less than " #ptr2 " for size %zu", (size)))
 
 /**
  * @brief Assumes that the given memory region is more than or equal to the expected memory region.
@@ -1816,7 +1816,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) >= 0, "Expected memory region " #ptr1 " to be more than or equal to " #ptr2)
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) >= 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to be more than or equal to " #ptr2 " for size %zu", (size)))
 
 /**
  * @brief Assumes that the given memory region is less than or equal to the expected memory region.
@@ -1826,8 +1826,8 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) <= 0, "Expected memory region " #ptr1 " to be less than or equal to " #ptr2)
-
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) <= 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to be less than or equal to " #ptr2 " for size %zu", (size)))
+    
 /**
  * @brief Assumes that the given memory region is not more than the expected memory region.
  *
@@ -1836,7 +1836,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_NOT_MORE_THAN_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) <= 0, "Expected memory region " #ptr1 " to not be more than " #ptr2)
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) <= 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to not be more than " #ptr2 " for size %zu", (size)))
 
 /**
  * @brief Assumes that the given memory region is not less than the expected memory region.
@@ -1846,7 +1846,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_NOT_LESS_THAN_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) >= 0, "Expected memory region " #ptr1 " to not be less than " #ptr2)
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) >= 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to not be less than " #ptr2 " for size %zu", (size)))
 
 /**
  * @brief Assumes that the given memory region is not more than or equal to the expected memory region.
@@ -1856,7 +1856,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) < 0, "Expected memory region " #ptr1 " to not be more than or equal to " #ptr2)
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) < 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to not be more than or equal to " #ptr2 " for size %zu", (size)))
 
 /**
  * @brief Assumes that the given memory region is not less than or equal to the expected memory region.
@@ -1866,7 +1866,7 @@ extern "C" {
  * @param size The size of the memory regions to compare.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_MEMORY(ptr1, ptr2, size) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) > 0, "Expected memory region " #ptr1 " to not be less than or equal to " #ptr2)
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_compare((ptr1), (ptr2), (size)) > 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory region " #ptr1 " to not be less than or equal to " #ptr2 " for size %zu", (size)))
 
 /**
  * @brief Assumes that the given memory pointer is valid.
@@ -1874,7 +1874,7 @@ extern "C" {
  * @param ptr A pointer to the memory to check.
  */
 #define ASSUME_ITS_VALID_MEMORY(ptr) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_is_valid((ptr)), "Expected memory pointer " #ptr " to be valid")
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_is_valid((ptr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory pointer " #ptr " to be valid"))
 
 /**
  * @brief Assumes that the given memory pointer is not valid.
@@ -1882,7 +1882,7 @@ extern "C" {
  * @param ptr A pointer to the memory to check.
  */
 #define ASSUME_NOT_VALID_MEMORY(ptr) \
-    FOSSIL_TEST_ASSUME(!pizza_sys_memory_is_valid((ptr)), "Expected memory pointer " #ptr " to not be valid")
+    FOSSIL_TEST_ASSUME(!pizza_sys_memory_is_valid((ptr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory pointer " #ptr " to not be valid"))
 
 // **************************************************
 //
@@ -1896,7 +1896,7 @@ extern "C" {
  * @param actual The pointer to be evaluated.
  */
 #define ASSUME_ITS_CNULL(actual) \
-    FOSSIL_TEST_ASSUME((actual) == null, "Expected " #actual " to be cnull")
+    FOSSIL_TEST_ASSUME((actual) == null, _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " to be cnull, but got %p", (actual)))
 
 /**
  * @brief Assumes that the given pointer is not cnull.
@@ -1904,7 +1904,7 @@ extern "C" {
  * @param actual The pointer to be evaluated.
  */
 #define ASSUME_NOT_CNULL(actual) \
-    FOSSIL_TEST_ASSUME((actual) != null, "Expected " #actual " to not be cnull")
+    FOSSIL_TEST_ASSUME((actual) != null, _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " to not be cnull, but got %p", (actual)))
 
 /**
  * @brief Assumes that the given pointer is cnull.
@@ -1912,7 +1912,7 @@ extern "C" {
  * @param actual The pointer to be evaluated.
  */
 #define ASSUME_ITS_CNULLABLE(actual) \
-    FOSSIL_TEST_ASSUME((actual) == null, "Expected " #actual " to be cnull")
+    FOSSIL_TEST_ASSUME((actual) == null, _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " to be cnull, but got %p", (actual)))
 
 /**
  * @brief Assumes that the given pointer is not cnull.
@@ -1920,7 +1920,7 @@ extern "C" {
  * @param actual The pointer to be evaluated.
  */
 #define ASSUME_NOT_CNULLABLE(actual) \
-    FOSSIL_TEST_ASSUME((actual) != null, "Expected " #actual " to not be cnull")
+    FOSSIL_TEST_ASSUME((actual) != null, _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " to not be cnull, but got %p", (actual)))
 
 /**
  * @brief Assumes that the given pointer is cnull.
@@ -1928,7 +1928,7 @@ extern "C" {
  * @param actual The pointer to be evaluated.
  */
 #define ASSUME_ITS_CNONNULL(actual) \
-    FOSSIL_TEST_ASSUME((actual) != null, "Expected " #actual " to not be cnull")
+    FOSSIL_TEST_ASSUME((actual) != null, _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " to not be cnull, but got %p", (actual)))
 
 /**
  * @brief Assumes that the given pointer is not cnull.
@@ -1936,7 +1936,7 @@ extern "C" {
  * @param actual The pointer to be evaluated.
  */
 #define ASSUME_NOT_CNONNULL(actual) \
-    FOSSIL_TEST_ASSUME((actual) == null, "Expected " #actual " to be cnull")
+    FOSSIL_TEST_ASSUME((actual) == null, _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " to be cnull, but got %p", (actual)))
 
 /**
  * @brief Assumes that the given condition is likely.
@@ -1944,7 +1944,7 @@ extern "C" {
  * @param x The condition to be evaluated.
  */
 #define ASSUME_ITS_LIKELY(x) \
-    FOSSIL_TEST_ASSUME(likely(x), "Expected " #x " to be likely")
+    FOSSIL_TEST_ASSUME(likely(x), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #x " to be likely, but got %d", (x)))
 
 /**
  * @brief Assumes that the given condition is not likely.
@@ -1952,7 +1952,7 @@ extern "C" {
  * @param x The condition to be evaluated.
  */
 #define ASSUME_NOT_LIKELY(x) \
-    FOSSIL_TEST_ASSUME(!likely(x), "Expected " #x " to not be likely")
+    FOSSIL_TEST_ASSUME(!likely(x), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #x " to not be likely, but got %d", (x)))
 
 /**
  * @brief Assumes that the given condition is unlikely.
@@ -1960,7 +1960,7 @@ extern "C" {
  * @param x The condition to be evaluated.
  */
 #define ASSUME_ITS_UNLIKELY(x) \
-    FOSSIL_TEST_ASSUME(unlikely(x), "Expected " #x " to be unlikely")
+    FOSSIL_TEST_ASSUME(unlikely(x), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #x " to be unlikely, but got %d", (x)))
 
 /**
  * @brief Assumes that the given condition is not unlikely.
@@ -1968,7 +1968,7 @@ extern "C" {
  * @param x The condition to be evaluated.
  */
 #define ASSUME_NOT_UNLIKELY(x) \
-    FOSSIL_TEST_ASSUME(!unlikely(x), "Expected " #x " to not be unlikely")
+    FOSSIL_TEST_ASSUME(!unlikely(x), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #x " to not be unlikely, but got %d", (x)))
 
 /**
  * @brief Assumes that the given pointers are equal.
@@ -1977,7 +1977,7 @@ extern "C" {
  * @param expected The expected pointer.
  */
 #define ASSUME_ITS_EQUAL_PTR(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) == (expected), "Expected pointer " #actual " to be equal to pointer " #expected " ")
+    FOSSIL_TEST_ASSUME((actual) == (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected pointer " #actual " of value %p to be equal to pointer " #expected " of value %p", (actual), (expected)))
 
 /**
  * @brief Assumes that the given pointers are not equal.
@@ -1986,7 +1986,7 @@ extern "C" {
  * @param expected The expected pointer.
  */
 #define ASSUME_NOT_EQUAL_PTR(actual, expected) \
-    FOSSIL_TEST_ASSUME((actual) != (expected), "Expected pointer " #actual " to not be equal to pointer " #expected " ")
+    FOSSIL_TEST_ASSUME((actual) != (expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected pointer " #actual " of value %p to not be equal to pointer " #expected " of value %p", (actual), (expected)))
 
 /**
  * @brief Assumes that the given size_t values are equal.
@@ -1995,7 +1995,7 @@ extern "C" {
  * @param expected The expected size_t value.
  */
 #define ASSUME_ITS_EQUAL_SIZE(actual, expected) \
-    FOSSIL_TEST_ASSUME((size_t)(actual) == (size_t)(expected), "Expected " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((size_t)(actual) == (size_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %zu to be equal to " #expected " of value %zu", (size_t)(actual), (size_t)(expected)))
 
 /**
  * @brief Assumes that the given size_t value is less than the expected value.
@@ -2004,7 +2004,7 @@ extern "C" {
  * @param expected The expected size_t value.
  */
 #define ASSUME_ITS_LESS_THAN_SIZE(actual, expected) \
-    FOSSIL_TEST_ASSUME((size_t)(actual) < (size_t)(expected), "Expected " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((size_t)(actual) < (size_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %zu to be less than " #expected " of value %zu", (size_t)(actual), (size_t)(expected)))
 
 /**
  * @brief Assumes that the given size_t value is more than the expected value.
@@ -2013,7 +2013,7 @@ extern "C" {
  * @param expected The expected size_t value.
  */
 #define ASSUME_ITS_MORE_THAN_SIZE(actual, expected) \
-    FOSSIL_TEST_ASSUME((size_t)(actual) > (size_t)(expected), "Expected " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((size_t)(actual) > (size_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %zu to be more than " #expected " of value %zu", (size_t)(actual), (size_t)(expected)))
 
 /**
  * @brief Assumes that the given size_t value is less than or equal to the expected value.
@@ -2022,7 +2022,7 @@ extern "C" {
  * @param expected The expected size_t value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_SIZE(actual, expected) \
-    FOSSIL_TEST_ASSUME((size_t)(actual) <= (size_t)(expected), "Expected " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((size_t)(actual) <= (size_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %zu to be less than or equal to " #expected " of value %zu", (size_t)(actual), (size_t)(expected)))
 
 /**
  * @brief Assumes that the given size_t value is more than or equal to the expected value.
@@ -2031,7 +2031,7 @@ extern "C" {
  * @param expected The expected size_t value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_SIZE(actual, expected) \
-    FOSSIL_TEST_ASSUME((size_t)(actual) >= (size_t)(expected), "Expected " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((size_t)(actual) >= (size_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %zu to be more than or equal to " #expected " of value %zu", (size_t)(actual), (size_t)(expected)))
 
 /**
  * @brief Assumes that the given size_t values are not equal.
@@ -2040,7 +2040,7 @@ extern "C" {
  * @param expected The expected size_t value.
  */
 #define ASSUME_NOT_EQUAL_SIZE(actual, expected) \
-    FOSSIL_TEST_ASSUME((size_t)(actual) != (size_t)(expected), "Expected " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((size_t)(actual) != (size_t)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected " #actual " of value %zu to not be equal to " #expected " of value %zu", (size_t)(actual), (size_t)(expected)))
 
 // **************************************************
 //
@@ -2056,7 +2056,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE(value, min, max) \
-    FOSSIL_TEST_ASSUME((value) >= (min) && (value) <= (max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((value) >= (min) && (value) <= (max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is not within range [" #min " of value %d, " #max " of value %d]", (value), (min), (max)))
 
 /**
  * @brief Assumes that the given value is not within the specified range.
@@ -2066,7 +2066,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE(value, min, max) \
-    FOSSIL_TEST_ASSUME((value) < (min) || (value) > (max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((value) < (min) || (value) > (max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is within range [" #min " of value %d, " #max " of value %d]", (value), (min), (max)))
 
 // Unsigned integer type assumptions
 
@@ -2078,7 +2078,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_U8(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint8_t)(value) >= (uint8_t)(min) && (uint8_t)(value) <= (uint8_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint8_t)(value) >= (uint8_t)(min) && (uint8_t)(value) <= (uint8_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is not within range [" #min " of value %u, " #max " of value %u]", (uint8_t)(value), (uint8_t)(min), (uint8_t)(max)))
 
 /**
  * @brief Assumes that the given 8-bit unsigned integer value is not within the specified range.
@@ -2088,7 +2088,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_U8(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint8_t)(value) < (uint8_t)(min) || (uint8_t)(value) > (uint8_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint8_t)(value) < (uint8_t)(min) || (uint8_t)(value) > (uint8_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is within range [" #min " of value %u, " #max " of value %u]", (uint8_t)(value), (uint8_t)(min), (uint8_t)(max)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is within the specified range.
@@ -2098,7 +2098,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_U16(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint16_t)(value) >= (uint16_t)(min) && (uint16_t)(value) <= (uint16_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint16_t)(value) >= (uint16_t)(min) && (uint16_t)(value) <= (uint16_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is not within range [" #min " of value %u, " #max " of value %u]", (uint16_t)(value), (uint16_t)(min), (uint16_t)(max)))
 
 /**
  * @brief Assumes that the given 16-bit unsigned integer value is not within the specified range.
@@ -2108,7 +2108,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_U16(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint16_t)(value) < (uint16_t)(min) || (uint16_t)(value) > (uint16_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint16_t)(value) < (uint16_t)(min) || (uint16_t)(value) > (uint16_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is within range [" #min " of value %u, " #max " of value %u]", (uint16_t)(value), (uint16_t)(min), (uint16_t)(max)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is within the specified range.
@@ -2118,7 +2118,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_U32(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint32_t)(value) >= (uint32_t)(min) && (uint32_t)(value) <= (uint32_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint32_t)(value) >= (uint32_t)(min) && (uint32_t)(value) <= (uint32_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is not within range [" #min " of value %u, " #max " of value %u]", (uint32_t)(value), (uint32_t)(min), (uint32_t)(max)))
 
 /**
  * @brief Assumes that the given 32-bit unsigned integer value is not within the specified range.
@@ -2128,7 +2128,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_U32(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint32_t)(value) < (uint32_t)(min) || (uint32_t)(value) > (uint32_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint32_t)(value) < (uint32_t)(min) || (uint32_t)(value) > (uint32_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is within range [" #min " of value %u, " #max " of value %u]", (uint32_t)(value), (uint32_t)(min), (uint32_t)(max)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is within the specified range.
@@ -2138,7 +2138,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_U64(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint64_t)(value) >= (uint64_t)(min) && (uint64_t)(value) <= (uint64_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint64_t)(value) >= (uint64_t)(min) && (uint64_t)(value) <= (uint64_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %llu is not within range [" #min " of value %llu, " #max " of value %llu]", (uint64_t)(value), (uint64_t)(min), (uint64_t)(max)))
 
 /**
  * @brief Assumes that the given 64-bit unsigned integer value is not within the specified range.
@@ -2148,7 +2148,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_U64(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint64_t)(value) < (uint64_t)(min) || (uint64_t)(value) > (uint64_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint64_t)(value) < (uint64_t)(min) || (uint64_t)(value) > (uint64_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %llu is within range [" #min " of value %llu, " #max " of value %llu]", (uint64_t)(value), (uint64_t)(min), (uint64_t)(max)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is within the specified range.
@@ -2158,7 +2158,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_I8(value, min, max) \
-    FOSSIL_TEST_ASSUME((int8_t)(value) >= (int8_t)(min) && (int8_t)(value) <= (int8_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int8_t)(value) >= (int8_t)(min) && (int8_t)(value) <= (int8_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is not within range [" #min " of value %d, " #max " of value %d]", (int8_t)(value), (int8_t)(min), (int8_t)(max)))
 
 /**
  * @brief Assumes that the given 8-bit integer value is not within the specified range.
@@ -2168,7 +2168,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_I8(value, min, max) \
-    FOSSIL_TEST_ASSUME((int8_t)(value) < (int8_t)(min) || (int8_t)(value) > (int8_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int8_t)(value) < (int8_t)(min) || (int8_t)(value) > (int8_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is within range [" #min " of value %d, " #max " of value %d]", (int8_t)(value), (int8_t)(min), (int8_t)(max)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is within the specified range.
@@ -2178,7 +2178,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_I16(value, min, max) \
-    FOSSIL_TEST_ASSUME((int16_t)(value) >= (int16_t)(min) && (int16_t)(value) <= (int16_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int16_t)(value) >= (int16_t)(min) && (int16_t)(value) <= (int16_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is not within range [" #min " of value %d, " #max " of value %d]", (int16_t)(value), (int16_t)(min), (int16_t)(max)))
 
 /**
  * @brief Assumes that the given 16-bit integer value is not within the specified range.
@@ -2188,7 +2188,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_I16(value, min, max) \
-    FOSSIL_TEST_ASSUME((int16_t)(value) < (int16_t)(min) || (int16_t)(value) > (int16_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int16_t)(value) < (int16_t)(min) || (int16_t)(value) > (int16_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is within range [" #min " of value %d, " #max " of value %d]", (int16_t)(value), (int16_t)(min), (int16_t)(max)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is within the specified range.
@@ -2198,7 +2198,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_I32(value, min, max) \
-    FOSSIL_TEST_ASSUME((int32_t)(value) >= (int32_t)(min) && (int32_t)(value) <= (int32_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int32_t)(value) >= (int32_t)(min) && (int32_t)(value) <= (int32_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is not within range [" #min " of value %d, " #max " of value %d]", (int32_t)(value), (int32_t)(min), (int32_t)(max)))
 
 /**
  * @brief Assumes that the given 32-bit integer value is not within the specified range.
@@ -2208,7 +2208,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_I32(value, min, max) \
-    FOSSIL_TEST_ASSUME((int32_t)(value) < (int32_t)(min) || (int32_t)(value) > (int32_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int32_t)(value) < (int32_t)(min) || (int32_t)(value) > (int32_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %d is within range [" #min " of value %d, " #max " of value %d]", (int32_t)(value), (int32_t)(min), (int32_t)(max)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is within the specified range.
@@ -2218,7 +2218,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_I64(value, min, max) \
-    FOSSIL_TEST_ASSUME((int64_t)(value) >= (int64_t)(min) && (int64_t)(value) <= (int64_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int64_t)(value) >= (int64_t)(min) && (int64_t)(value) <= (int64_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %lld is not within range [" #min " of value %lld, " #max " of value %lld]", (int64_t)(value), (int64_t)(min), (int64_t)(max)))
 
 /**
  * @brief Assumes that the given 64-bit integer value is not within the specified range.
@@ -2228,7 +2228,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_I64(value, min, max) \
-    FOSSIL_TEST_ASSUME((int64_t)(value) < (int64_t)(min) || (int64_t)(value) > (int64_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((int64_t)(value) < (int64_t)(min) || (int64_t)(value) > (int64_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %lld is within range [" #min " of value %lld, " #max " of value %lld]", (int64_t)(value), (int64_t)(min), (int64_t)(max)))
 
 /**
  * @brief Assumes that the given float value is within the specified range.
@@ -2238,7 +2238,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_F32(value, min, max) \
-    FOSSIL_TEST_ASSUME((value) >= (min) && (value) <= (max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((value) >= (min) && (value) <= (max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %f is not within range [" #min " of value %f, " #max " of value %f]", (value), (min), (max)))
 
 /**
  * @brief Assumes that the given float value is not within the specified range.
@@ -2248,7 +2248,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_F32(value, min, max) \
-    FOSSIL_TEST_ASSUME((value) < (min) || (value) > (max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((value) < (min) || (value) > (max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %f is within range [" #min " of value %f, " #max " of value %f]", (value), (min), (max)))
 
 /**
  * @brief Assumes that the given double value is within the specified range.
@@ -2258,7 +2258,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_F64(value, min, max) \
-    FOSSIL_TEST_ASSUME((value) >= (min) && (value) <= (max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((value) >= (min) && (value) <= (max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %f is not within range [" #min " of value %f, " #max " of value %f]", (value), (min), (max)))
 
 /**
  * @brief Assumes that the given double value is not within the specified range.
@@ -2268,9 +2268,9 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_F64(value, min, max) \
-    FOSSIL_TEST_ASSUME((value) < (min) || (value) > (max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((value) < (min) || (value) > (max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %f is within range [" #min " of value %f, " #max " of value %f]", (value), (min), (max)))
 
-// Byte char type assumtions (uint8_t)
+// Byte char type assumptions (uint8_t)
 
 /**
  * @brief Assumes that the given byte char value is within the specified range.
@@ -2280,7 +2280,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_BCHAR(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint8_t)(value) >= (uint8_t)(min) && (uint8_t)(value) <= (uint8_t)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint8_t)(value) >= (uint8_t)(min) && (uint8_t)(value) <= (uint8_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is not within range [" #min " of value %u, " #max " of value %u]", (uint8_t)(value), (uint8_t)(min), (uint8_t)(max)))
 
 /**
  * @brief Assumes that the given byte char value is not within the specified range.
@@ -2290,9 +2290,9 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_BCHAR(value, min, max) \
-    FOSSIL_TEST_ASSUME((uint8_t)(value) < (uint8_t)(min) || (uint8_t)(value) > (uint8_t)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((uint8_t)(value) < (uint8_t)(min) || (uint8_t)(value) > (uint8_t)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %u is within range [" #min " of value %u, " #max " of value %u]", (uint8_t)(value), (uint8_t)(min), (uint8_t)(max)))
 
-// Char type assumtions (char)
+// Char type assumptions (char)
 
 /**
  * @brief Assumes that the given char value is within the specified range.
@@ -2302,7 +2302,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_ITS_WITHIN_RANGE_CCHAR(value, min, max) \
-    FOSSIL_TEST_ASSUME((char)(value) >= (char)(min) && (char)(value) <= (char)(max), "Value " #value " is not within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((char)(value) >= (char)(min) && (char)(value) <= (char)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %c is not within range [" #min " of value %c, " #max " of value %c]", (char)(value), (char)(min), (char)(max)))
 
 /**
  * @brief Assumes that the given char value is not within the specified range.
@@ -2312,7 +2312,7 @@ extern "C" {
  * @param max The maximum value of the range.
  */
 #define ASSUME_NOT_WITHIN_RANGE_CCHAR(value, min, max) \
-    FOSSIL_TEST_ASSUME((char)(value) < (char)(min) || (char)(value) > (char)(max), "Value " #value " is within range [" #min ", " #max "]")
+    FOSSIL_TEST_ASSUME((char)(value) < (char)(min) || (char)(value) > (char)(max), _FOSSIL_TEST_ASSUME_MESSAGE("Value " #value " of value %c is within range [" #min " of value %c, " #max " of value %c]", (char)(value), (char)(min), (char)(max)))
 
 // **************************************************
 //
@@ -2327,7 +2327,7 @@ extern "C" {
  * @param expected The expected C string.
  */
 #define ASSUME_ITS_EQUAL_CSTR(actual, expected) \
-    FOSSIL_TEST_ASSUME(strcmp((actual), (expected)) == 0, "Expected C string " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME(strcmp((actual), (expected)) == 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected C string " #actual " of value \"%s\" to be equal to " #expected " of value \"%s\"", (actual), (expected)))
 
 /**
  * @brief Assumes that the given C strings are not equal.
@@ -2336,7 +2336,7 @@ extern "C" {
  * @param expected The expected C string.
  */
 #define ASSUME_NOT_EQUAL_CSTR(actual, expected) \
-    FOSSIL_TEST_ASSUME(strcmp((actual), (expected)) != 0, "Expected C string " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME(strcmp((actual), (expected)) != 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected C string " #actual " of value \"%s\" to not be equal to " #expected " of value \"%s\"", (actual), (expected)))
 
 /**
  * @brief Assumes that the length of the given C string is equal to the expected length.
@@ -2345,7 +2345,7 @@ extern "C" {
  * @param expected_len The expected length of the C string.
  */
 #define ASSUME_ITS_LENGTH_EQUAL_CSTR(actual, expected_len) \
-    FOSSIL_TEST_ASSUME(strlen((actual)) == (expected_len), "Expected length of C string " #actual " to be equal to " #expected_len)
+    FOSSIL_TEST_ASSUME(strlen((actual)) == (expected_len), _FOSSIL_TEST_ASSUME_MESSAGE("Expected length of C string " #actual " of value \"%s\" to be equal to " #expected_len " of value %zu", (actual), (expected_len)))
 
 /**
  * @brief Assumes that the length of the given C string is not equal to the expected length.
@@ -2354,7 +2354,7 @@ extern "C" {
  * @param expected_len The expected length of the C string.
  */
 #define ASSUME_NOT_LENGTH_EQUAL_CSTR(actual, expected_len) \
-    FOSSIL_TEST_ASSUME(strlen((actual)) != (expected_len), "Expected length of C string " #actual " to not be equal to " #expected_len)
+    FOSSIL_TEST_ASSUME(strlen((actual)) != (expected_len), _FOSSIL_TEST_ASSUME_MESSAGE("Expected length of C string " #actual " of value \"%s\" to not be equal to " #expected_len " of value %zu", (actual), (expected_len)))
 
 /**
  * @brief Assumes that the given cstr starts with the specified prefix.
@@ -2363,7 +2363,7 @@ extern "C" {
  * @param prefix The prefix to check for.
  */
 #define ASSUME_ITS_CSTR_STARTS_WITH(str, prefix) \
-    FOSSIL_TEST_ASSUME(pizza_io_cstr_starts_with((str), (prefix)), "Expected cstr " #str " to start with prefix " #prefix)
+    FOSSIL_TEST_ASSUME(pizza_io_cstr_starts_with((str), (prefix)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to start with prefix " #prefix " of value \"%s\"", (str), (prefix)))
 
 /**
  * @brief Assumes that the given cstr does not start with the specified prefix.
@@ -2372,7 +2372,7 @@ extern "C" {
  * @param prefix The prefix to check for.
  */
 #define ASSUME_NOT_CSTR_STARTS_WITH(str, prefix) \
-    FOSSIL_TEST_ASSUME(!pizza_io_cstr_starts_with((str), (prefix)), "Expected cstr " #str " to not start with prefix " #prefix)
+    FOSSIL_TEST_ASSUME(!pizza_io_cstr_starts_with((str), (prefix)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to not start with prefix " #prefix " of value \"%s\"", (str), (prefix)))
 
 /**
  * @brief Assumes that the given cstr ends with the specified suffix.
@@ -2381,7 +2381,7 @@ extern "C" {
  * @param suffix The suffix to check for.
  */
 #define ASSUME_ITS_CSTR_ENDS_WITH(str, suffix) \
-    FOSSIL_TEST_ASSUME(pizza_io_cstr_ends_with((str), (suffix)), "Expected cstr " #str " to end with suffix " #suffix)
+    FOSSIL_TEST_ASSUME(pizza_io_cstr_ends_with((str), (suffix)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to end with suffix " #suffix " of value \"%s\"", (str), (suffix)))
 
 /**
  * @brief Assumes that the given cstr does not end with the specified suffix.
@@ -2390,7 +2390,7 @@ extern "C" {
  * @param suffix The suffix to check for.
  */
 #define ASSUME_NOT_CSTR_ENDS_WITH(str, suffix) \
-    FOSSIL_TEST_ASSUME(!pizza_io_cstr_ends_with((str), (suffix)), "Expected cstr " #str " to not end with suffix " #suffix)
+    FOSSIL_TEST_ASSUME(!pizza_io_cstr_ends_with((str), (suffix)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to not end with suffix " #suffix " of value \"%s\"", (str), (suffix)))
 
 /**
  * @brief Assumes that the given cstr contains the specified substring.
@@ -2399,7 +2399,7 @@ extern "C" {
  * @param substr The substring to check for.
  */
 #define ASSUME_ITS_CSTR_CONTAINS(str, substr) \
-    FOSSIL_TEST_ASSUME(pizza_io_cstr_contains((str), (substr)), "Expected cstr " #str " to contain substring " #substr)
+    FOSSIL_TEST_ASSUME(pizza_io_cstr_contains((str), (substr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to contain substring " #substr " of value \"%s\"", (str), (substr)))
 
 /**
  * @brief Assumes that the given cstr does not contain the specified substring.
@@ -2408,7 +2408,7 @@ extern "C" {
  * @param substr The substring to check for.
  */
 #define ASSUME_NOT_CSTR_CONTAINS(str, substr) \
-    FOSSIL_TEST_ASSUME(!pizza_io_cstr_contains((str), (substr)), "Expected cstr " #str " to not contain substring " #substr)
+    FOSSIL_TEST_ASSUME(!pizza_io_cstr_contains((str), (substr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to not contain substring " #substr " of value \"%s\"", (str), (substr)))
 
 /**
  * @brief Assumes that the given cstr contains the specified number of occurrences of a substring.
@@ -2418,7 +2418,7 @@ extern "C" {
  * @param count The expected number of occurrences.
  */
 #define ASSUME_ITS_CSTR_COUNT(str, substr, count) \
-    FOSSIL_TEST_ASSUME(pizza_io_cstr_count((str), (substr)) == (count), "Expected cstr " #str " to contain " #count " occurrences of substring " #substr)
+    FOSSIL_TEST_ASSUME(pizza_io_cstr_count((str), (substr)) == (count), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to contain " #count " occurrences of substring " #substr " of value \"%s\"", (str), (substr), (count)))
 
 /**
  * @brief Assumes that the given cstr does not contain the specified number of occurrences of a substring.
@@ -2428,7 +2428,7 @@ extern "C" {
  * @param count The expected number of occurrences.
  */
 #define ASSUME_NOT_CSTR_COUNT(str, substr, count) \
-    FOSSIL_TEST_ASSUME(pizza_io_cstr_count((str), (substr)) != (count), "Expected cstr " #str " to not contain " #count " occurrences of substring " #substr)
+    FOSSIL_TEST_ASSUME(pizza_io_cstr_count((str), (substr)) != (count), _FOSSIL_TEST_ASSUME_MESSAGE("Expected cstr " #str " of value \"%s\" to not contain " #count " occurrences of substring " #substr " of value \"%s\"", (str), (substr), (count)))
 
 // **************************************************
 //
@@ -2443,7 +2443,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_ITS_EQUAL_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) == (char)(expected), "Expected char " #actual " to be equal to " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) == (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to be equal to " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char values are not equal.
@@ -2452,7 +2452,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_NOT_EQUAL_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) != (char)(expected), "Expected char " #actual " to not be equal to " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) != (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to not be equal to " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is less than the expected value.
@@ -2461,7 +2461,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_ITS_LESS_THAN_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) < (char)(expected), "Expected char " #actual " to be less than " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) < (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to be less than " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is more than the expected value.
@@ -2470,7 +2470,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_ITS_MORE_THAN_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) > (char)(expected), "Expected char " #actual " to be more than " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) > (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to be more than " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is less than or equal to the expected value.
@@ -2479,7 +2479,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_ITS_LESS_OR_EQUAL_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) <= (char)(expected), "Expected char " #actual " to be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) <= (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to be less than or equal to " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is more than or equal to the expected value.
@@ -2488,7 +2488,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_ITS_MORE_OR_EQUAL_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) >= (char)(expected), "Expected char " #actual " to be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) >= (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to be more than or equal to " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is not less than the expected value.
@@ -2497,7 +2497,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_NOT_LESS_THAN_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) >= (char)(expected), "Expected char " #actual " to not be less than " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) >= (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to not be less than " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is not more than the expected value.
@@ -2506,7 +2506,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_NOT_MORE_THAN_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) <= (char)(expected), "Expected char " #actual " to not be more than " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) <= (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to not be more than " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is not less than or equal to the expected value.
@@ -2515,7 +2515,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_NOT_LESS_OR_EQUAL_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) > (char)(expected), "Expected char " #actual " to not be less than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) > (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to not be less than or equal to " #expected " of value %c", (char)(actual), (char)(expected)))
 
 /**
  * @brief Assumes that the given char value is not more than or equal to the expected value.
@@ -2524,7 +2524,7 @@ extern "C" {
  * @param expected The expected char value.
  */
 #define ASSUME_NOT_MORE_OR_EQUAL_CHAR(actual, expected) \
-    FOSSIL_TEST_ASSUME((char)(actual) < (char)(expected), "Expected char " #actual " to not be more than or equal to " #expected)
+    FOSSIL_TEST_ASSUME((char)(actual) < (char)(expected), _FOSSIL_TEST_ASSUME_MESSAGE("Expected char " #actual " of value %c to not be more than or equal to " #expected " of value %c", (char)(actual), (char)(expected)))
 
 // **************************************************
 // SOAP assumptions
@@ -2536,7 +2536,7 @@ extern "C" {
  * @param text The input text to check.
  */
 #define ASSUME_NOT_SOAP_ROT_BRAIN(text) \
-    FOSSIL_TEST_ASSUME(!pizza_io_is_rot_brain((text)), "Expected text " #text " to not contain 'rot-brain' language")
+    FOSSIL_TEST_ASSUME(!pizza_io_is_rot_brain((text)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected text " #text " of value \"%s\" to not contain 'rot-brain' language", (text)))
 
 /**
  * @brief Assumes that the given text contains "rot-brain" language.
@@ -2544,7 +2544,7 @@ extern "C" {
  * @param text The input text to check.
  */
 #define ASSUME_ITS_SOAP_ROT_BRAIN(text) \
-    FOSSIL_TEST_ASSUME(pizza_io_is_rot_brain((text)), "Expected text " #text " to contain 'rot-brain' language")
+    FOSSIL_TEST_ASSUME(pizza_io_is_rot_brain((text)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected text " #text " of value \"%s\" to contain 'rot-brain' language", (text)))
 
 /**
  * @brief Assumes that the tone of the given sentence is detected correctly.
@@ -2553,7 +2553,7 @@ extern "C" {
  * @param expected_tone The expected tone ("formal", "casual", "sarcastic", etc.).
  */
 #define ASSUME_ITS_SOAP_TONE_DETECTED(text, expected_tone) \
-    FOSSIL_TEST_ASSUME(strcmp(pizza_io_soap_detect_tone((text)), (expected_tone)) == 0, "Expected tone of text " #text " to be " #expected_tone)
+    FOSSIL_TEST_ASSUME(strcmp(pizza_io_soap_detect_tone((text)), (expected_tone)) == 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected tone of text " #text " of value \"%s\" to be " #expected_tone " of value \"%s\"", (text), (expected_tone)))
 
 /**
  * @brief Assumes that the tone of the given sentence is not detected correctly.
@@ -2562,7 +2562,7 @@ extern "C" {
  * @param expected_tone The expected tone ("formal", "casual", "sarcastic", etc.).
  */
 #define ASSUME_NOT_SOAP_TONE_DETECTED(text, expected_tone) \
-    FOSSIL_TEST_ASSUME(strcmp(pizza_io_soap_detect_tone((text)), (expected_tone)) != 0, "Expected tone of text " #text " to not be " #expected_tone)
+    FOSSIL_TEST_ASSUME(strcmp(pizza_io_soap_detect_tone((text)), (expected_tone)) != 0, _FOSSIL_TEST_ASSUME_MESSAGE("Expected tone of text " #text " of value \"%s\" to not be " #expected_tone " of value \"%s\"", (text), (expected_tone)))
 
 #ifdef __cplusplus
 }

--- a/code/logic/fossil/pizza/assume.h
+++ b/code/logic/fossil/pizza/assume.h
@@ -1874,7 +1874,7 @@ extern "C" {
  * @param ptr A pointer to the memory to check.
  */
 #define ASSUME_ITS_VALID_MEMORY(ptr) \
-    FOSSIL_TEST_ASSUME(pizza_sys_memory_is_valid((ptr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory pointer " #ptr " to be valid"))
+    FOSSIL_TEST_ASSUME(pizza_sys_memory_is_valid((ptr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory pointer " #ptr " to be valid", null))
 
 /**
  * @brief Assumes that the given memory pointer is not valid.
@@ -1882,7 +1882,7 @@ extern "C" {
  * @param ptr A pointer to the memory to check.
  */
 #define ASSUME_NOT_VALID_MEMORY(ptr) \
-    FOSSIL_TEST_ASSUME(!pizza_sys_memory_is_valid((ptr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory pointer " #ptr " to not be valid"))
+    FOSSIL_TEST_ASSUME(!pizza_sys_memory_is_valid((ptr)), _FOSSIL_TEST_ASSUME_MESSAGE("Expected memory pointer " #ptr " to not be valid", null))
 
 // **************************************************
 //

--- a/code/logic/fossil/pizza/common.h
+++ b/code/logic/fossil/pizza/common.h
@@ -533,7 +533,7 @@ pizza_sys_memory_t pizza_sys_memory_dup(const pizza_sys_memory_t src, size_t siz
  * @param size The size of the memory to zero.
  * @throws Error message and exits if the pointer is NULL.
  */
-void pizza_sys_memory_zero(pizza_sys_memory_t ptr, size_t size);
+pizza_sys_memory_t pizza_sys_memory_zero(pizza_sys_memory_t ptr, size_t size);
 
 /**
  * Compare memory.

--- a/code/logic/fossil/pizza/common.h
+++ b/code/logic/fossil/pizza/common.h
@@ -690,6 +690,30 @@ void pizza_io_puts(const char *str);
 void pizza_io_printf(const char *format, ...);
 
 /**
+ * Prints a formatted string to a buffer using a va_list.
+ *
+ * This function is similar to `vsnprintf`, but it allows for custom formatting
+ * markers enclosed in curly braces `{}`, such as `{red}` for color or `{bold}` for
+ * text attributes. The formatted string is written to the provided buffer.
+ *
+ * Example usage:
+ * ```c
+ * char buffer[100];
+ * va_list args;
+ * va_start(args, format);
+ * pizza_io_vsnprintf(buffer, sizeof(buffer), format, args);
+ * va_end(args);
+ * ```
+ *
+ * @param buffer The buffer where the formatted string will be written.
+ * @param size The size of the buffer.
+ * @param format The format string, which contains the text to be formatted, along with format specifiers.
+ * @param args The variable argument list containing the values to be formatted.
+ * @return The number of characters written (excluding the null terminator), or a negative value if an error occurs.
+ */
+int pizza_io_vsnprintf(char *buffer, size_t size, const char *format, va_list args);
+
+/**
  * Prints a character to the output.
  * 
  * This function is a basic utility to print a single character to the output. It is especially useful when you

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -545,8 +545,13 @@ void _on_skip(const char *description);
     * runner. If the condition is false, the test runner will output the specified
     * message and may abort the execution of the test case or test suite.
     */ 
+#ifdef _WIN32
+#define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
+    pizza_test_assert_messagef((message), __VA_ARGS__)
+#else
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
     pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
+#endif
 
 /**
  * @brief Macro for defining a Given step in a behavior-driven development test.

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -551,9 +551,6 @@ void _on_skip(const char *description);
 #elif defined(__APPLE__)
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
     pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
-#elif defined(__linux__)
-#define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
-    pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
 #else
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
     pizza_test_assert_messagef((message), ##__VA_ARGS__)

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -557,7 +557,7 @@ void _on_skip(const char *description);
     pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
 #else
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
-    pizza_test_assert_messagef((message), ##__VA_ARGS__)
+    pizza_test_assert_messagef((message) , __VA_ARGS__)
 #endif
 #endif
 

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -546,7 +546,7 @@ void _on_skip(const char *description);
     * message and may abort the execution of the test case or test suite.
     */ 
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
-    pizza_test_assert_messagef((message), ##__VA_ARGS__)
+    pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
 
 /**
  * @brief Macro for defining a Given step in a behavior-driven development test.

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -546,46 +546,46 @@ void _on_skip(const char *description);
     * message and may abort the execution of the test case or test suite.
     */ 
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
-         pizza_test_assert_messagef((message) __VA_OPT__(, ) __VA_ARGS__)
+    pizza_test_assert_messagef((message), ##__VA_ARGS__)
 
- /**
-    * @brief Macro for defining a Given step in a behavior-driven development test.
-    * 
-    * This macro is used to define a Given step in a behavior-driven development test.
-    * The Given step is used to specify the initial context of a test case.
-    * 
-    * @param description The description of the Given step.
-    */
- #define _GIVEN(description) \
-         if (0) { \
-                 _given(description); \
-         }
- 
- /**
-    * @brief Macro for defining a When step in a behavior-driven development test.
-    * 
-    * This macro is used to define a When step in a behavior-driven development test.
-    * The When step is used to specify the action that is being tested.
-    * 
-    * @param description The description of the When step.
-    */
- #define _WHEN(description) \
-         if (0) { \
-                 _when(description); \
-         }
- 
- /**
-    * @brief Macro for defining a Then step in a behavior-driven development test.
-    * 
-    * This macro is used to define a Then step in a behavior-driven development test.
-    * The Then step is used to specify the expected outcome of a test case.
-    * 
-    * @param description The description of the Then step.
-    */
- #define _THEN(description) \
-         if (0) { \
-                 _then(description); \
-         }
+/**
+ * @brief Macro for defining a Given step in a behavior-driven development test.
+ * 
+ * This macro is used to define a Given step in a behavior-driven development test.
+ * The Given step is used to specify the initial context of a test case.
+ * 
+ * @param description The description of the Given step.
+ */
+#define _GIVEN(description) \
+    if (0) { \
+        _given(description); \
+    }
+
+/**
+ * @brief Macro for defining a When step in a behavior-driven development test.
+ * 
+ * This macro is used to define a When step in a behavior-driven development test.
+ * The When step is used to specify the action that is being tested.
+ * 
+ * @param description The description of the When step.
+ */
+#define _WHEN(description) \
+    if (0) { \
+        _when(description); \
+    }
+
+/**
+ * @brief Macro for defining a Then step in a behavior-driven development test.
+ * 
+ * This macro is used to define a Then step in a behavior-driven development test.
+ * The Then step is used to specify the expected outcome of a test case.
+ * 
+ * @param description The description of the Then step.
+ */
+#define _THEN(description) \
+    if (0) { \
+        _then(description); \
+    }
 
 // *****************************************************************************
 // Public API Macros

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -149,6 +149,8 @@ int32_t fossil_pizza_end(fossil_pizza_engine_t* engine);
  */
 void pizza_test_assert_internal(bool condition, const char *message, const char *file, int line, const char *func);
 
+char *pizza_test_assert_messagef(const char *message, ...);
+
 // *********************************************************************************************
 // internal messages
 // *********************************************************************************************
@@ -537,7 +539,15 @@ void _on_skip(const char *description);
  #define _FOSSIL_TEST_ASSERT(condition, message) \
          pizza_test_assert_internal((condition), (message), __FILE__, __LINE__, __func__)
  
- 
+/**
+    * @brief Macro to assume a condition in a test runner.
+    * This macro is used to assert that a specific condition is true within a test
+    * runner. If the condition is false, the test runner will output the specified
+    * message and may abort the execution of the test case or test suite.
+    */ 
+#define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
+         pizza_test_assert_messagef((message), ##__VA_ARGS__)
+
  /**
     * @brief Macro for defining a Given step in a behavior-driven development test.
     * 

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -546,7 +546,7 @@ void _on_skip(const char *description);
     * message and may abort the execution of the test case or test suite.
     */ 
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
-         pizza_test_assert_messagef((message), ##__VA_ARGS__)
+         pizza_test_assert_messagef((message) __VA_OPT__(, ) __VA_ARGS__)
 
  /**
     * @brief Macro for defining a Given step in a behavior-driven development test.

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -548,6 +548,12 @@ void _on_skip(const char *description);
 #ifdef _WIN32
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
     pizza_test_assert_messagef((message), __VA_ARGS__)
+#elif defined(__APPLE__)
+#define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
+    pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
+#elif defined(__linux__)
+#define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
+    pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
 #else
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
     pizza_test_assert_messagef((message), ##__VA_ARGS__)

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -552,8 +552,13 @@ void _on_skip(const char *description);
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
     pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
 #else
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201710L
+#define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
+    pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
+#else
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
     pizza_test_assert_messagef((message), ##__VA_ARGS__)
+#endif
 #endif
 
 /**

--- a/code/logic/fossil/pizza/test.h
+++ b/code/logic/fossil/pizza/test.h
@@ -550,7 +550,7 @@ void _on_skip(const char *description);
     pizza_test_assert_messagef((message), __VA_ARGS__)
 #else
 #define _FOSSIL_TEST_ASSUME_MESSAGE(message, ...) \
-    pizza_test_assert_messagef((message) __VA_OPT__(, __VA_ARGS__))
+    pizza_test_assert_messagef((message), ##__VA_ARGS__)
 #endif
 
 /**

--- a/code/logic/test.c
+++ b/code/logic/test.c
@@ -708,6 +708,19 @@ int32_t fossil_pizza_end(fossil_pizza_engine_t* engine) {
 
 // -- Assume --
 
+char *pizza_test_assert_messagef(const char *message, ...) {
+    va_list args;
+    va_start(args, message);
+    size_t buffer_size = 1024; // Define a reasonable buffer size
+    char *formatted_message = (char *)pizza_sys_memory_alloc(buffer_size);
+    if (formatted_message) {
+        pizza_io_vsnprintf(formatted_message, buffer_size, message, args);
+        formatted_message[buffer_size - 1] = '\0'; // Ensure null-termination
+    }
+    va_end(args);
+    return formatted_message;
+}
+
 void pizza_test_assert_internal_output(const char *message, const char *file, int line, const char *func, int anomaly_count) {
     // Output assertion failure based on theme
     switch (G_PIZZA_THEME) {

--- a/code/tests/cases/test_mark.c
+++ b/code/tests/cases/test_mark.c
@@ -51,11 +51,93 @@ FOSSIL_TEST(c_mark_start_and_stop) {
     ASSUME_ITS_EQUAL_CSTR(benchmark_stop_test.name, "stop_test");
 }
 
+// Test case for MARK_BENCHMARK
+FOSSIL_TEST(c_mark_benchmark) {
+    MARK_BENCHMARK(test_benchmark);
+    ASSUME_ITS_EQUAL_CSTR(benchmark_test_benchmark.name, "test_benchmark");
+}
+
+// Test case for MARK_START
+FOSSIL_TEST(c_mark_start) {
+    MARK_BENCHMARK(start_test);
+    MARK_START(start_test);
+    ASSUME_ITS_TRUE(benchmark_start_test.running);
+}
+
+// Test case for MARK_STOP
+FOSSIL_TEST(c_mark_stop) {
+    MARK_BENCHMARK(stop_test);
+    MARK_START(stop_test);
+    MARK_STOP(stop_test);
+    ASSUME_ITS_FALSE(benchmark_stop_test.running);
+}
+
+// Test case for MARK_BENCHMARK with multiple benchmarks
+FOSSIL_TEST(c_mark_multiple_benchmarks) {
+    MARK_BENCHMARK(benchmark1);
+    MARK_BENCHMARK(benchmark2);
+    ASSUME_ITS_EQUAL_CSTR(benchmark_benchmark1.name, "benchmark1");
+    ASSUME_ITS_EQUAL_CSTR(benchmark_benchmark2.name, "benchmark2");
+}
+
+// Test case for MARK_START and MARK_STOP with elapsed time
+FOSSIL_TEST(c_mark_elapsed_time) {
+    MARK_BENCHMARK(elapsed_test);
+    MARK_START(elapsed_test);
+    // Simulate some work
+    for (volatile int i = 0; i < 1000000; ++i);
+    MARK_STOP(elapsed_test);
+    ASSUME_ITS_TRUE(benchmark_elapsed_test.total_duration > 0.0);
+}
+
+// Test case for MARK_BENCHMARK with invalid name
+FOSSIL_TEST(c_mark_invalid_benchmark_name) {
+    MARK_BENCHMARK(null_benchmark);
+    ASSUME_NOT_CNULL(benchmark_null_benchmark.name);
+}
+
+// Test case for MARK_STOP without MARK_START
+FOSSIL_TEST(c_mark_stop_without_start) {
+    MARK_BENCHMARK(stop_without_start);
+    MARK_STOP(stop_without_start);
+    ASSUME_ITS_FALSE(benchmark_stop_without_start.running);
+}
+
+// Test case for MARK_BENCHMARK with nested benchmarks
+FOSSIL_TEST(c_mark_nested_benchmarks) {
+    MARK_BENCHMARK(outer_benchmark);
+    MARK_START(outer_benchmark);
+    MARK_BENCHMARK(inner_benchmark);
+    MARK_START(inner_benchmark);
+    MARK_STOP(inner_benchmark);
+    MARK_STOP(outer_benchmark);
+    ASSUME_ITS_TRUE(benchmark_outer_benchmark.total_duration >= benchmark_inner_benchmark.total_duration);
+}
+
+// Test case for resetting a benchmark
+FOSSIL_TEST(c_mark_reset_benchmark) {
+    MARK_BENCHMARK(reset_test);
+    MARK_START(reset_test);
+    MARK_STOP(reset_test);
+    fossil_benchmark_reset(&benchmark_reset_test);
+    ASSUME_ITS_EQUAL_I32(benchmark_reset_test.total_duration, 0.0);
+    ASSUME_ITS_EQUAL_I32(benchmark_reset_test.num_samples, 0);
+}
+
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Pool
 // * * * * * * * * * * * * * * * * * * * * * * * *
 FOSSIL_TEST_GROUP(c_mark_test_cases) {
     FOSSIL_TEST_ADD(c_mark_suite, c_mark_start_and_stop);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_benchmark);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_start);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_stop);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_multiple_benchmarks);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_elapsed_time);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_invalid_benchmark_name);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_stop_without_start);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_nested_benchmarks);
+    FOSSIL_TEST_ADD(c_mark_suite, c_mark_reset_benchmark);
 
     FOSSIL_TEST_REGISTER(c_mark_suite);
 }

--- a/code/tests/cases/test_mark.c
+++ b/code/tests/cases/test_mark.c
@@ -85,7 +85,7 @@ FOSSIL_TEST(c_mark_elapsed_time) {
     MARK_BENCHMARK(elapsed_test);
     MARK_START(elapsed_test);
     // Simulate some work
-    for (volatile int i = 0; i < 1000000; ++i);
+    for (int i = 0; i < 1000000; ++i);
     MARK_STOP(elapsed_test);
     ASSUME_ITS_TRUE(benchmark_elapsed_test.total_duration > 0.0);
 }

--- a/code/tests/cases/test_mark.cpp
+++ b/code/tests/cases/test_mark.cpp
@@ -85,7 +85,7 @@
      MARK_BENCHMARK(elapsed_test);
      MARK_START(elapsed_test);
      // Simulate some work
-     for (volatile int i = 0; i < 1000000; ++i);
+     for (int i = 0; i < 1000000; ++i);
      MARK_STOP(elapsed_test);
      ASSUME_ITS_TRUE(benchmark_elapsed_test.total_duration > 0.0);
  }

--- a/code/tests/cases/test_mark.cpp
+++ b/code/tests/cases/test_mark.cpp
@@ -13,51 +13,132 @@
  * -----------------------------------------------------------------------------
  */
 
-#include "fossil/pizza/framework.h"
-#include <string>
+ #include "fossil/pizza/framework.h"
 
-// * * * * * * * * * * * * * * * * * * * * * * * *
-// * Fossil Logic Test Utilites
-// * * * * * * * * * * * * * * * * * * * * * * * *
-// Setup steps for things like test fixtures and
-// mock objects are set here.
-// * * * * * * * * * * * * * * * * * * * * * * * *
-
-// Define the test suite and add test cases
-FOSSIL_SUITE(cpp_mark_suite);
-
-// Setup function for the test suite
-FOSSIL_SETUP(cpp_mark_suite) {
-    // Setup code here
-}
-
-// Teardown function for the test suite
-FOSSIL_TEARDOWN(cpp_mark_suite) {
-    // Teardown code here
-}
-
-// * * * * * * * * * * * * * * * * * * * * * * * *
-// * Fossil Logic Test Cases
-// * * * * * * * * * * * * * * * * * * * * * * * *
-// The test cases below are provided as samples, inspired
-// by the Meson build system's approach of using test cases
-// as samples for library usage.
-// * * * * * * * * * * * * * * * * * * * * * * * *
-
-// A test case to check if the benchmark stop works correctly
-FOSSIL_TEST(cpp_mark_start_and_stop) {
-    std::string benchmark_stop_test_name = "stop_test";
-    MARK_BENCHMARK(stop_test);
-    MARK_START(stop_test);
-    MARK_STOP(stop_test);
-    ASSUME_ITS_EQUAL_CSTR(benchmark_stop_test.name, benchmark_stop_test_name.c_str());
-}
-
-// * * * * * * * * * * * * * * * * * * * * * * * *
-// * Fossil Logic Test Pool
-// * * * * * * * * * * * * * * * * * * * * * * * *
-FOSSIL_TEST_GROUP(cpp_mark_test_cases) {
-    FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_start_and_stop);
-
-    FOSSIL_TEST_REGISTER(cpp_mark_suite);
-}
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ // * Fossil Logic Test Utilites
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ // Setup steps for things like test fixtures and
+ // mock objects are set here.
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ 
+ // Define the test suite and add test cases
+ FOSSIL_SUITE(cpp_mark_suite);
+ 
+ // Setup function for the test suite
+ FOSSIL_SETUP(cpp_mark_suite) {
+     // Setup code here
+ }
+ 
+ // Teardown function for the test suite
+ FOSSIL_TEARDOWN(cpp_mark_suite) {
+     // Teardown code here
+ }
+ 
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ // * Fossil Logic Test Cases
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ // The test cases below are provided as samples, inspired
+ // by the Meson build system's approach of using test cases
+ // as samples for library usage.
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ 
+ // A test case to check if the benchmark stop works correctly
+ FOSSIL_TEST(cpp_mark_start_and_stop) {
+     MARK_BENCHMARK(stop_test);
+     MARK_START(stop_test);
+     MARK_STOP(stop_test);
+     ASSUME_ITS_EQUAL_CSTR(benchmark_stop_test.name, "stop_test");
+ }
+ 
+ // Test case for MARK_BENCHMARK
+ FOSSIL_TEST(cpp_mark_benchmark) {
+     MARK_BENCHMARK(test_benchmark);
+     ASSUME_ITS_EQUAL_CSTR(benchmark_test_benchmark.name, "test_benchmark");
+ }
+ 
+ // Test case for MARK_START
+ FOSSIL_TEST(cpp_mark_start) {
+     MARK_BENCHMARK(start_test);
+     MARK_START(start_test);
+     ASSUME_ITS_TRUE(benchmark_start_test.running);
+ }
+ 
+ // Test case for MARK_STOP
+ FOSSIL_TEST(cpp_mark_stop) {
+     MARK_BENCHMARK(stop_test);
+     MARK_START(stop_test);
+     MARK_STOP(stop_test);
+     ASSUME_ITS_FALSE(benchmark_stop_test.running);
+ }
+ 
+ // Test case for MARK_BENCHMARK with multiple benchmarks
+ FOSSIL_TEST(cpp_mark_multiple_benchmarks) {
+     MARK_BENCHMARK(benchmark1);
+     MARK_BENCHMARK(benchmark2);
+     ASSUME_ITS_EQUAL_CSTR(benchmark_benchmark1.name, "benchmark1");
+     ASSUME_ITS_EQUAL_CSTR(benchmark_benchmark2.name, "benchmark2");
+ }
+ 
+ // Test case for MARK_START and MARK_STOP with elapsed time
+ FOSSIL_TEST(cpp_mark_elapsed_time) {
+     MARK_BENCHMARK(elapsed_test);
+     MARK_START(elapsed_test);
+     // Simulate some work
+     for (volatile int i = 0; i < 1000000; ++i);
+     MARK_STOP(elapsed_test);
+     ASSUME_ITS_TRUE(benchmark_elapsed_test.total_duration > 0.0);
+ }
+ 
+ // Test case for MARK_BENCHMARK with invalid name
+ FOSSIL_TEST(cpp_mark_invalid_benchmark_name) {
+     MARK_BENCHMARK(null_benchmark);
+     ASSUME_NOT_CNULL(benchmark_null_benchmark.name);
+ }
+ 
+ // Test case for MARK_STOP without MARK_START
+ FOSSIL_TEST(cpp_mark_stop_without_start) {
+     MARK_BENCHMARK(stop_without_start);
+     MARK_STOP(stop_without_start);
+     ASSUME_ITS_FALSE(benchmark_stop_without_start.running);
+ }
+ 
+ // Test case for MARK_BENCHMARK with nested benchmarks
+ FOSSIL_TEST(cpp_mark_nested_benchmarks) {
+     MARK_BENCHMARK(outer_benchmark);
+     MARK_START(outer_benchmark);
+     MARK_BENCHMARK(inner_benchmark);
+     MARK_START(inner_benchmark);
+     MARK_STOP(inner_benchmark);
+     MARK_STOP(outer_benchmark);
+     ASSUME_ITS_TRUE(benchmark_outer_benchmark.total_duration >= benchmark_inner_benchmark.total_duration);
+ }
+ 
+ // Test case for resetting a benchmark
+ FOSSIL_TEST(cpp_mark_reset_benchmark) {
+     MARK_BENCHMARK(reset_test);
+     MARK_START(reset_test);
+     MARK_STOP(reset_test);
+     fossil_benchmark_reset(&benchmark_reset_test);
+     ASSUME_ITS_EQUAL_I32(benchmark_reset_test.total_duration, 0.0);
+     ASSUME_ITS_EQUAL_I32(benchmark_reset_test.num_samples, 0);
+ }
+ 
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ // * Fossil Logic Test Pool
+ // * * * * * * * * * * * * * * * * * * * * * * * *
+ FOSSIL_TEST_GROUP(cpp_mark_test_cases) {
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_start_and_stop);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_benchmark);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_start);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_stop);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_multiple_benchmarks);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_elapsed_time);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_invalid_benchmark_name);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_stop_without_start);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_nested_benchmarks);
+     FOSSIL_TEST_ADD(cpp_mark_suite, cpp_mark_reset_benchmark);
+ 
+     FOSSIL_TEST_REGISTER(cpp_mark_suite);
+ }
+ 

--- a/code/tests/cases/test_tdd.c
+++ b/code/tests/cases/test_tdd.c
@@ -665,7 +665,7 @@ FOSSIL_TEST(c_assume_run_of_within_range_cchar) {
     ASSUME_NOT_WITHIN_RANGE_CCHAR(y, 'C', 'Z');
 } // end case
 
-FOSSIL_TEST(c_assume_run_of_cstr) {
+FOSSIL_TEST(c_assume_run_of_cstr_equality) {
     const char *str1 = "Hello";
     const char *str2 = "Hello";
     const char *str3 = "World";
@@ -673,8 +673,277 @@ FOSSIL_TEST(c_assume_run_of_cstr) {
     // Test cases
     ASSUME_ITS_EQUAL_CSTR(str1, str2);
     ASSUME_NOT_EQUAL_CSTR(str1, str3);
-    ASSUME_ITS_LENGTH_EQUAL_CSTR(str1, 5);
 } // end case
+
+FOSSIL_TEST(c_assume_run_of_cstr_length) {
+    const char *str1 = "Hello";
+
+    // Test cases
+    ASSUME_ITS_LENGTH_EQUAL_CSTR(str1, 5);
+    ASSUME_NOT_LENGTH_EQUAL_CSTR(str1, 10);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_cstr_prefix) {
+    const char *str4 = "Hello, World!";
+    const char *prefix = "Hello";
+    const char *str3 = "World";
+
+    // Test cases
+    ASSUME_ITS_CSTR_STARTS_WITH(str4, prefix);
+    ASSUME_NOT_CSTR_STARTS_WITH(str3, prefix);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_cstr_suffix) {
+    const char *str4 = "Hello, World!";
+    const char *suffix = "World!";
+    const char *str1 = "Hello";
+
+    // Test cases
+    ASSUME_ITS_CSTR_ENDS_WITH(str4, suffix);
+    ASSUME_NOT_CSTR_ENDS_WITH(str1, suffix);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_cstr_contains) {
+    const char *str4 = "Hello, World!";
+    const char *substr = "lo";
+    const char *str3 = "World";
+
+    // Test cases
+    ASSUME_ITS_CSTR_CONTAINS(str4, substr);
+    ASSUME_NOT_CSTR_CONTAINS(str3, substr);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_cstr_count) {
+    const char *str4 = "Hello, World!";
+
+    // Test cases
+    ASSUME_ITS_CSTR_COUNT(str4, "o", 2);
+    ASSUME_NOT_CSTR_COUNT(str4, "o", 3);
+} // end case
+
+
+FOSSIL_TEST(c_assume_run_of_zero_memory) {
+    char buffer[10] = {0};
+
+    // Test cases
+    ASSUME_ITS_ZERO_MEMORY(buffer, sizeof(buffer));
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_memory_equality) {
+    char buffer1[10] = {0};
+    char buffer2[10] = {0};
+    char buffer3[10] = {1};
+
+    // Test cases
+    ASSUME_ITS_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_ITS_NOT_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_memory_comparison) {
+    char buffer1[10] = {1, 2, 3};
+    char buffer2[10] = {1, 2, 4};
+    char buffer3[10] = {1, 2, 3};
+
+    // Test cases
+    ASSUME_ITS_LESS_THAN_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_ITS_MORE_THAN_MEMORY(buffer2, buffer1, sizeof(buffer1));
+    ASSUME_ITS_MORE_OR_EQUAL_MEMORY(buffer2, buffer1, sizeof(buffer1));
+    ASSUME_ITS_LESS_OR_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_memory_validity) {
+    char buffer[10];
+    char *valid_ptr = buffer;
+    char *invalid_ptr = NULL;
+
+    // Test cases
+    ASSUME_ITS_VALID_MEMORY(valid_ptr);
+    ASSUME_NOT_VALID_MEMORY(invalid_ptr);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_memory_range) {
+    char buffer1[10] = {1, 2, 3};
+    char buffer2[10] = {1, 2, 4};
+
+    // Test cases
+    ASSUME_NOT_MORE_THAN_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_NOT_LESS_THAN_MEMORY(buffer2, buffer1, sizeof(buffer1));
+    ASSUME_NOT_MORE_OR_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_NOT_LESS_OR_EQUAL_MEMORY(buffer2, buffer1, sizeof(buffer1));
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_pointer_nullability) {
+    void *ptr1 = NULL;
+    void *ptr2 = (void *)0x1;
+
+    // Test cases
+    ASSUME_ITS_CNULLABLE(ptr1);
+    ASSUME_NOT_CNULLABLE(ptr2);
+    ASSUME_ITS_CNONNULL(ptr2);
+    ASSUME_NOT_CNONNULL(ptr1);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_likely_conditions) {
+    int a = 5;
+    int b = 10;
+
+    // Test cases
+    ASSUME_ITS_LIKELY(a < b);
+    ASSUME_NOT_LIKELY(a > b);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_unlikely_conditions) {
+    int a = 5;
+    int b = 10;
+
+    // Test cases
+    ASSUME_ITS_UNLIKELY(a < b);
+    ASSUME_NOT_UNLIKELY(a > b);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_pointer_nullability_complex) {
+    int a = 42;
+    int *ptr1 = &a;
+    int *ptr2 = NULL;
+
+    // Test cases
+    ASSUME_ITS_CNONNULL(ptr1);
+    ASSUME_NOT_CNULLABLE(ptr1);
+    ASSUME_ITS_CNULLABLE(ptr2);
+    ASSUME_NOT_CNONNULL(ptr2);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_likely_unlikely_combination) {
+    int a = 5;
+    int b = 10;
+
+    // Test cases
+    ASSUME_ITS_LIKELY(a < b);
+    ASSUME_ITS_UNLIKELY(a < b);
+    ASSUME_NOT_LIKELY(a > b);
+    ASSUME_NOT_UNLIKELY(a > b);
+} // end case
+
+
+FOSSIL_TEST(c_assume_run_of_char_equality) {
+    char x = 'A';
+    char z = 'A';
+
+    // Test cases
+    ASSUME_ITS_EQUAL_CHAR(x, z);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_inequality) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_EQUAL_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_less_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_ITS_LESS_THAN_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_more_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_ITS_MORE_THAN_CHAR(y, x);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_less_or_equal) {
+    char x = 'A';
+    char z = 'A';
+
+    // Test cases
+    ASSUME_ITS_LESS_OR_EQUAL_CHAR(x, z);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_more_or_equal) {
+    char x = 'A';
+    char z = 'A';
+
+    // Test cases
+    ASSUME_ITS_MORE_OR_EQUAL_CHAR(x, z);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_not_less_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_LESS_THAN_CHAR(y, x);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_not_more_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_MORE_THAN_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_not_less_or_equal) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_LESS_OR_EQUAL_CHAR(y, x);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_not_more_or_equal) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_MORE_OR_EQUAL_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_char_not_equal) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_EQUAL_CHAR(x, y);
+} // end case
+
+
+FOSSIL_TEST(c_assume_run_of_not_soap_rot_brain) {
+    const char *text = "This is a normal sentence.";
+
+    // Test case
+    ASSUME_NOT_SOAP_ROT_BRAIN(text);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_its_soap_rot_brain) {
+    const char *text = "This is a rot-brain sentence.";
+
+    // Test case
+    ASSUME_ITS_SOAP_ROT_BRAIN(text);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_its_soap_tone_detected) {
+    const char *text = "Respectfully testing the pizza.";
+    const char *expected_tone = "formal";
+
+    // Test case
+    ASSUME_ITS_SOAP_TONE_DETECTED(text, expected_tone);
+} // end case
+
+FOSSIL_TEST(c_assume_run_of_not_soap_tone_detected) {
+    const char *text = "This is a sarcastic sentence.";
+    const char *expected_tone = "formal";
+
+    // Test case
+    ASSUME_NOT_SOAP_TONE_DETECTED(text, expected_tone);
+} // end case
+
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Pool
@@ -736,7 +1005,37 @@ FOSSIL_TEST_GROUP(c_tdd_test_cases) {
     FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_within_range_f64);
     FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_within_range_bchar);
     FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_within_range_cchar);
-    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr_equality);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr_length);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr_prefix);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr_suffix);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr_contains);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_cstr_count);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_zero_memory);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_memory_equality);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_memory_comparison);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_memory_validity);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_memory_range);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_pointer_nullability);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_likely_conditions);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_unlikely_conditions);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_pointer_nullability_complex);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_likely_unlikely_combination);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_equality);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_inequality);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_less_than);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_more_than);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_less_or_equal);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_more_or_equal);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_not_less_than);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_not_more_than);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_not_less_or_equal);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_not_more_or_equal);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_char_not_equal);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_not_soap_rot_brain);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_its_soap_rot_brain);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_its_soap_tone_detected);
+    FOSSIL_TEST_ADD(c_tdd_suite, c_assume_run_of_not_soap_tone_detected);
 
     FOSSIL_TEST_REGISTER(c_tdd_suite);
 } // end of group

--- a/code/tests/cases/test_tdd.c
+++ b/code/tests/cases/test_tdd.c
@@ -736,7 +736,7 @@ FOSSIL_TEST(c_assume_run_of_memory_equality) {
 
     // Test cases
     ASSUME_ITS_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
-    ASSUME_ITS_NOT_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
+    ASSUME_NOT_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
 } // end case
 
 FOSSIL_TEST(c_assume_run_of_memory_comparison) {
@@ -766,9 +766,13 @@ FOSSIL_TEST(c_assume_run_of_memory_range) {
     char buffer2[10] = {1, 2, 4};
 
     // Test cases
+    ASSUME_ITS_MORE_THAN_MEMORY(buffer2, buffer1, sizeof(buffer1));
     ASSUME_NOT_MORE_THAN_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_ITS_LESS_THAN_MEMORY(buffer1, buffer2, sizeof(buffer1));
     ASSUME_NOT_LESS_THAN_MEMORY(buffer2, buffer1, sizeof(buffer1));
+    ASSUME_ITS_MORE_OR_EQUAL_MEMORY(buffer2, buffer1, sizeof(buffer1));
     ASSUME_NOT_MORE_OR_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_ITS_LESS_OR_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
     ASSUME_NOT_LESS_OR_EQUAL_MEMORY(buffer2, buffer1, sizeof(buffer1));
 } // end case
 

--- a/code/tests/cases/test_tdd.cpp
+++ b/code/tests/cases/test_tdd.cpp
@@ -13,7 +13,6 @@
  * -----------------------------------------------------------------------------
  */
 #include <fossil/pizza/framework.h>
-#include <string>
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Utilites
@@ -368,51 +367,51 @@ FOSSIL_TEST(cpp_assume_run_of_hex64_shortcut) {
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_octal8_shortcut) {
-    int8_t x = 042; // Octal for 42
-    int8_t y = 020; // Octal for 20
+    int8_t x = 052; // Octal for 42
+    int8_t y = 024; // Octal for 20
 
     // Test cases
-    ASSUME_ITS_EQUAL_O8((int8_t)x, 042);
-    ASSUME_ITS_EQUAL_O8((int8_t)y, 020);
-    ASSUME_NOT_EQUAL_O8((int8_t)x, (int8_t)y);
-    ASSUME_ITS_LESS_THAN_O8((int8_t)y, (int8_t)x);
-    ASSUME_ITS_LESS_OR_EQUAL_O8((int8_t)y, (int8_t)x);
+    ASSUME_ITS_EQUAL_O8(x, 052);
+    ASSUME_ITS_EQUAL_O8(y, 024);
+    ASSUME_NOT_EQUAL_O8(x, y);
+    ASSUME_ITS_LESS_THAN_O8(y, x);
+    ASSUME_ITS_LESS_OR_EQUAL_O8(y, x);
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_octal16_shortcut) {
-    int16_t x = 042; // Octal for 42
-    int16_t y = 020; // Octal for 20
+    int16_t x = 052; // Octal for 42
+    int16_t y = 024; // Octal for 20
 
     // Test cases
-    ASSUME_ITS_EQUAL_O16((int16_t)x, 042);
-    ASSUME_ITS_EQUAL_O16((int16_t)y, 020);
-    ASSUME_NOT_EQUAL_O16((int16_t)x, (int16_t)y);
-    ASSUME_ITS_LESS_THAN_O16((int16_t)y, (int16_t)x);
-    ASSUME_ITS_LESS_OR_EQUAL_O16((int16_t)y, (int16_t)x);
+    ASSUME_ITS_EQUAL_O16(x, 052);
+    ASSUME_ITS_EQUAL_O16(y, 024);
+    ASSUME_NOT_EQUAL_O16(x, y);
+    ASSUME_ITS_LESS_THAN_O16(y, x);
+    ASSUME_ITS_LESS_OR_EQUAL_O16(y, x);
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_octal32_shortcut) {
-    int32_t x = 042; // Octal for 42
-    int32_t y = 020; // Octal for 20
+    int32_t x = 052; // Octal for 42
+    int32_t y = 024; // Octal for 20
 
     // Test cases
-    ASSUME_ITS_EQUAL_O32((int32_t)x, 042);
-    ASSUME_ITS_EQUAL_O32((int32_t)y, 020);
-    ASSUME_NOT_EQUAL_O32((int32_t)x, (int32_t)y);
-    ASSUME_ITS_LESS_THAN_O32((int32_t)y, (int32_t)x);
-    ASSUME_ITS_LESS_OR_EQUAL_O32((int32_t)y, (int32_t)x);
+    ASSUME_ITS_EQUAL_O32(x, 052);
+    ASSUME_ITS_EQUAL_O32(y, 024);
+    ASSUME_NOT_EQUAL_O32(x, y);
+    ASSUME_ITS_LESS_THAN_O32(y, x);
+    ASSUME_ITS_LESS_OR_EQUAL_O32(y, x);
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_octal64_shortcut) {
-    int64_t x = 042; // Octal for 42
-    int64_t y = 020; // Octal for 20
+    int64_t x = 052; // Octal for 42
+    int64_t y = 024; // Octal for 20
 
     // Test cases
-    ASSUME_ITS_EQUAL_O64((int64_t)x, 042);
-    ASSUME_ITS_EQUAL_O64((int64_t)y, 020);
-    ASSUME_NOT_EQUAL_O64((int64_t)x, (int64_t)y);
-    ASSUME_ITS_LESS_THAN_O64((int64_t)y, (int64_t)x);
-    ASSUME_ITS_LESS_OR_EQUAL_O64((int64_t)y, (int64_t)x);
+    ASSUME_ITS_EQUAL_O64(x, 052);
+    ASSUME_ITS_EQUAL_O64(y, 024);
+    ASSUME_NOT_EQUAL_O64(x, y);
+    ASSUME_ITS_LESS_THAN_O64(y, x);
+    ASSUME_ITS_LESS_OR_EQUAL_O64(y, x);
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_float32) {
@@ -508,18 +507,18 @@ FOSSIL_TEST(cpp_assume_run_of_boolean_complex_expression_negation) {
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_null_pointer) {
-    void *ptr = nullptr;
+    void *ptr = NULL;
 
     // Test cases
     ASSUME_ITS_CNULL(ptr);
-    ASSUME_NOT_CNULL((void *)0x1); // Assuming a non-nullptr pointer
+    ASSUME_NOT_CNULL((void *)0x1); // Assuming a non-null pointer
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_pointer_equality) {
     int a = 42;
     int *ptr1 = &a;
     int *ptr2 = &a;
-    int *ptr3 = nullptr;
+    int *ptr3 = NULL;
 
     // Test cases
     ASSUME_ITS_EQUAL_PTR(ptr1, ptr2);
@@ -666,17 +665,285 @@ FOSSIL_TEST(cpp_assume_run_of_within_range_cchar) {
     ASSUME_NOT_WITHIN_RANGE_CCHAR(y, 'C', 'Z');
 } // end case
 
-
-FOSSIL_TEST(cpp_assume_run_of_cstr) {
-    std::string str1 = "Hello";
-    std::string str2 = "Hello";
-    std::string str3 = "World";
+FOSSIL_TEST(cpp_assume_run_of_cstr_equality) {
+    const char *str1 = "Hello";
+    const char *str2 = "Hello";
+    const char *str3 = "World";
 
     // Test cases
-    ASSUME_ITS_EQUAL_CSTR(str1.c_str(), str2.c_str());
-    ASSUME_NOT_EQUAL_CSTR(str1.c_str(), str3.c_str());
-    ASSUME_ITS_LENGTH_EQUAL_CSTR(str1.c_str(), 5);
+    ASSUME_ITS_EQUAL_CSTR(str1, str2);
+    ASSUME_NOT_EQUAL_CSTR(str1, str3);
 } // end case
+
+FOSSIL_TEST(cpp_assume_run_of_cstr_length) {
+    const char *str1 = "Hello";
+
+    // Test cases
+    ASSUME_ITS_LENGTH_EQUAL_CSTR(str1, 5);
+    ASSUME_NOT_LENGTH_EQUAL_CSTR(str1, 10);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_cstr_prefix) {
+    const char *str4 = "Hello, World!";
+    const char *prefix = "Hello";
+    const char *str3 = "World";
+
+    // Test cases
+    ASSUME_ITS_CSTR_STARTS_WITH(str4, prefix);
+    ASSUME_NOT_CSTR_STARTS_WITH(str3, prefix);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_cstr_suffix) {
+    const char *str4 = "Hello, World!";
+    const char *suffix = "World!";
+    const char *str1 = "Hello";
+
+    // Test cases
+    ASSUME_ITS_CSTR_ENDS_WITH(str4, suffix);
+    ASSUME_NOT_CSTR_ENDS_WITH(str1, suffix);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_cstr_contains) {
+    const char *str4 = "Hello, World!";
+    const char *substr = "lo";
+    const char *str3 = "World";
+
+    // Test cases
+    ASSUME_ITS_CSTR_CONTAINS(str4, substr);
+    ASSUME_NOT_CSTR_CONTAINS(str3, substr);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_cstr_count) {
+    const char *str4 = "Hello, World!";
+
+    // Test cases
+    ASSUME_ITS_CSTR_COUNT(str4, "o", 2);
+    ASSUME_NOT_CSTR_COUNT(str4, "o", 3);
+} // end case
+
+
+FOSSIL_TEST(cpp_assume_run_of_zero_memory) {
+    char buffer[10] = {0};
+
+    // Test cases
+    ASSUME_ITS_ZERO_MEMORY(buffer, sizeof(buffer));
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_memory_equality) {
+    char buffer1[10] = {0};
+    char buffer2[10] = {0};
+    char buffer3[10] = {1};
+
+    // Test cases
+    ASSUME_ITS_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_ITS_NOT_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_memory_comparison) {
+    char buffer1[10] = {1, 2, 3};
+    char buffer2[10] = {1, 2, 4};
+    char buffer3[10] = {1, 2, 3};
+
+    // Test cases
+    ASSUME_ITS_LESS_THAN_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_ITS_MORE_THAN_MEMORY(buffer2, buffer1, sizeof(buffer1));
+    ASSUME_ITS_MORE_OR_EQUAL_MEMORY(buffer2, buffer1, sizeof(buffer1));
+    ASSUME_ITS_LESS_OR_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_memory_validity) {
+    char buffer[10];
+    char *valid_ptr = buffer;
+    char *invalid_ptr = NULL;
+
+    // Test cases
+    ASSUME_ITS_VALID_MEMORY(valid_ptr);
+    ASSUME_NOT_VALID_MEMORY(invalid_ptr);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_memory_range) {
+    char buffer1[10] = {1, 2, 3};
+    char buffer2[10] = {1, 2, 4};
+
+    // Test cases
+    ASSUME_NOT_MORE_THAN_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_NOT_LESS_THAN_MEMORY(buffer2, buffer1, sizeof(buffer1));
+    ASSUME_NOT_MORE_OR_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
+    ASSUME_NOT_LESS_OR_EQUAL_MEMORY(buffer2, buffer1, sizeof(buffer1));
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_pointer_nullability) {
+    void *ptr1 = NULL;
+    void *ptr2 = (void *)0x1;
+
+    // Test cases
+    ASSUME_ITS_CNULLABLE(ptr1);
+    ASSUME_NOT_CNULLABLE(ptr2);
+    ASSUME_ITS_CNONNULL(ptr2);
+    ASSUME_NOT_CNONNULL(ptr1);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_likely_conditions) {
+    int a = 5;
+    int b = 10;
+
+    // Test cases
+    ASSUME_ITS_LIKELY(a < b);
+    ASSUME_NOT_LIKELY(a > b);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_unlikely_conditions) {
+    int a = 5;
+    int b = 10;
+
+    // Test cases
+    ASSUME_ITS_UNLIKELY(a < b);
+    ASSUME_NOT_UNLIKELY(a > b);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_pointer_nullability_complex) {
+    int a = 42;
+    int *ptr1 = &a;
+    int *ptr2 = NULL;
+
+    // Test cases
+    ASSUME_ITS_CNONNULL(ptr1);
+    ASSUME_NOT_CNULLABLE(ptr1);
+    ASSUME_ITS_CNULLABLE(ptr2);
+    ASSUME_NOT_CNONNULL(ptr2);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_likely_unlikely_combination) {
+    int a = 5;
+    int b = 10;
+
+    // Test cases
+    ASSUME_ITS_LIKELY(a < b);
+    ASSUME_ITS_UNLIKELY(a < b);
+    ASSUME_NOT_LIKELY(a > b);
+    ASSUME_NOT_UNLIKELY(a > b);
+} // end case
+
+
+FOSSIL_TEST(cpp_assume_run_of_char_equality) {
+    char x = 'A';
+    char z = 'A';
+
+    // Test cases
+    ASSUME_ITS_EQUAL_CHAR(x, z);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_inequality) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_EQUAL_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_less_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_ITS_LESS_THAN_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_more_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_ITS_MORE_THAN_CHAR(y, x);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_less_or_equal) {
+    char x = 'A';
+    char z = 'A';
+
+    // Test cases
+    ASSUME_ITS_LESS_OR_EQUAL_CHAR(x, z);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_more_or_equal) {
+    char x = 'A';
+    char z = 'A';
+
+    // Test cases
+    ASSUME_ITS_MORE_OR_EQUAL_CHAR(x, z);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_not_less_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_LESS_THAN_CHAR(y, x);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_not_more_than) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_MORE_THAN_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_not_less_or_equal) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_LESS_OR_EQUAL_CHAR(y, x);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_not_more_or_equal) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_MORE_OR_EQUAL_CHAR(x, y);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_char_not_equal) {
+    char x = 'A';
+    char y = 'B';
+
+    // Test cases
+    ASSUME_NOT_EQUAL_CHAR(x, y);
+} // end case
+
+
+FOSSIL_TEST(cpp_assume_run_of_not_soap_rot_brain) {
+    const char *text = "This is a normal sentence.";
+
+    // Test case
+    ASSUME_NOT_SOAP_ROT_BRAIN(text);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_its_soap_rot_brain) {
+    const char *text = "This is a rot-brain sentence.";
+
+    // Test case
+    ASSUME_ITS_SOAP_ROT_BRAIN(text);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_its_soap_tone_detected) {
+    const char *text = "Respectfully testing the pizza.";
+    const char *expected_tone = "formal";
+
+    // Test case
+    ASSUME_ITS_SOAP_TONE_DETECTED(text, expected_tone);
+} // end case
+
+FOSSIL_TEST(cpp_assume_run_of_not_soap_tone_detected) {
+    const char *text = "This is a sarcastic sentence.";
+    const char *expected_tone = "formal";
+
+    // Test case
+    ASSUME_NOT_SOAP_TONE_DETECTED(text, expected_tone);
+} // end case
+
 
 // * * * * * * * * * * * * * * * * * * * * * * * *
 // * Fossil Logic Test Pool
@@ -738,7 +1005,37 @@ FOSSIL_TEST_GROUP(cpp_tdd_test_cases) {
     FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_within_range_f64);
     FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_within_range_bchar);
     FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_within_range_cchar);
-    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr_equality);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr_length);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr_prefix);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr_suffix);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr_contains);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_cstr_count);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_zero_memory);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_memory_equality);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_memory_comparison);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_memory_validity);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_memory_range);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_pointer_nullability);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_likely_conditions);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_unlikely_conditions);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_pointer_nullability_complex);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_likely_unlikely_combination);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_equality);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_inequality);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_less_than);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_more_than);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_less_or_equal);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_more_or_equal);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_not_less_than);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_not_more_than);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_not_less_or_equal);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_not_more_or_equal);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_char_not_equal);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_not_soap_rot_brain);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_its_soap_rot_brain);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_its_soap_tone_detected);
+    FOSSIL_TEST_ADD(cpp_tdd_suite, cpp_assume_run_of_not_soap_tone_detected);
 
     FOSSIL_TEST_REGISTER(cpp_tdd_suite);
 } // end of group

--- a/code/tests/cases/test_tdd.cpp
+++ b/code/tests/cases/test_tdd.cpp
@@ -736,7 +736,7 @@ FOSSIL_TEST(cpp_assume_run_of_memory_equality) {
 
     // Test cases
     ASSUME_ITS_EQUAL_MEMORY(buffer1, buffer2, sizeof(buffer1));
-    ASSUME_ITS_NOT_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
+    ASSUME_NOT_EQUAL_MEMORY(buffer1, buffer3, sizeof(buffer1));
 } // end case
 
 FOSSIL_TEST(cpp_assume_run_of_memory_comparison) {


### PR DESCRIPTION
# Fossil Test - Pull Request

## Description
This PR add more test cases to cover new assumptions for soap, char, memory and more, not only that cases have been added for mark as will.

Last notable change is that now assume will display both the variable name and value stored in variable to better inform the tester about the failed result and avoid the black box issue.

## Testing
New test cases for new assumptions and new cases for benchmark.

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
