### PR TITLE
Add timeout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The Pizza Test CLI provides an efficient way to run and manage tests directly fr
 | `color=<mode>`                   | Set color mode (enable, disable, auto).                                                       | Enhances readability in supported terminals.                                                  |
 | `theme=<name>`                   | Set the theme (pizza, catch, doctest, etc.).                                                 | Customizes the appearance of test output.                                                     |
 | `verbose=<level>`                | Set verbosity level (plain, ci, doge).                                                        | Adjusts the level of detail in test output.                                                   |
+| `timeout=<seconds>`              | Set a timeout for test execution.                                                             | Ensures tests do not exceed the specified duration, helping to identify long-running tests.   |
 
 ### Run Command Options
 | Option               | Description                                                                                   | Notes                                                                                         |

--- a/code/logic/common.c
+++ b/code/logic/common.c
@@ -367,6 +367,16 @@ fossil_pizza_pallet_t fossil_pizza_pallet_create(int argc, char** argv) {
             if (i + 1 < argc && pizza_io_cstr_compare(argv[i + 1], "--help") == 0) {
                 _show_subhelp_verbose();
             }
+        } else if (strncmp(argv[i], "timeout=", 8) == 0) {
+            G_PIZZA_TIMEOUT = atoi(argv[i] + 8);
+        } else if (pizza_io_cstr_compare(argv[i], "timeout") == 0) {
+            if (i + 1 < argc && pizza_io_cstr_compare(argv[i + 1], "--help") == 0) {
+                _show_help();
+                exit(EXIT_SUCCESS);
+            }
+        } else {
+            pizza_io_printf("{red}Error: Unknown command or option '%s'.{reset}\n", argv[i]);
+            exit(EXIT_FAILURE);
         }
     }
 

--- a/code/logic/common.c
+++ b/code/logic/common.c
@@ -27,6 +27,7 @@
 // exported flags
 // *****************************************************************************
 
+uint64_t G_PIZZA_TIMEOUT = 60; // Default timeout in seconds
 int G_PIZZA_DRY_RUN = 0;
 int G_PIZZA_FAIL_FAST = 0;
 int G_PIZZA_SKIP = 0;
@@ -77,6 +78,7 @@ static void _show_help(void) {
     pizza_io_printf("{cyan}  color=<mode>       Set color mode (enable, disable, auto){reset}\n");
     pizza_io_printf("{cyan}  theme=<name>       Set the theme (fossil, catch, doctest, etc.){reset}\n");
     pizza_io_printf("{cyan}  verbose=<level>    Set verbosity level (plain, ci, doge){reset}\n");
+    pizza_io_printf("{cyan}  timeout=<seconds>  Set the timeout for commands (default: 60 seconds){reset}\n");
     exit(EXIT_SUCCESS);
 }
 

--- a/code/logic/fossil/pizza/common.h
+++ b/code/logic/fossil/pizza/common.h
@@ -325,6 +325,7 @@ typedef struct {
 // exported flags
 // *****************************************************************************
 
+extern uint64_t G_PIZZA_TIMEOUT;
 extern int G_PIZZA_DRY_RUN;
 extern int G_PIZZA_FAIL_FAST;
 extern int G_PIZZA_SKIP;

--- a/code/logic/test.c
+++ b/code/logic/test.c
@@ -107,9 +107,12 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
     if (!test_case) return;
 
     const char* result_str = 
+        (test_case->result == FOSSIL_PIZZA_CASE_EMPTY) ? "EMPTY" :
         (test_case->result == FOSSIL_PIZZA_CASE_PASS) ? "PASS" :
         (test_case->result == FOSSIL_PIZZA_CASE_FAIL) ? "FAIL" :
-        (test_case->result == FOSSIL_PIZZA_CASE_EMPTY) ? "EMPTY" : "UNKNOWN";
+        (test_case->result == FOSSIL_PIZZA_CASE_TIMEOUT) ? "TIMEOUT" :
+        (test_case->result == FOSSIL_PIZZA_CASE_SKIPPED) ? "SKIPPED" :
+        (test_case->result == FOSSIL_PIZZA_CASE_UNEXPECTED) ? "UNEXPECTED" : "UNKNOWN";
 
     switch (G_PIZZA_THEME) {
         case PIZZA_THEME_FOSSIL:
@@ -118,8 +121,10 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
                 test_case->name, result_str, test_case->elapsed_ns);
             } else if (G_PIZZA_VERBOSE == PIZZA_VERBOSE_DOGE) {
             pizza_io_printf("{blue}========================================{reset}\n");
-            pizza_io_printf("{cyan}Test Case:{reset} %s\n", test_case->name);
-            pizza_io_printf("{cyan}Given Result:{reset} %s\n", result_str);
+            pizza_io_printf("{cyan}Test Case     :{reset} %s\n", test_case->name);
+            pizza_io_printf("{cyan}Given Tags    :{reset} %s\n", test_case->tags);
+            pizza_io_printf("{cyan}Given Criteria:{reset} %s\n", test_case->criteria);
+            pizza_io_printf("{cyan}Given Result  :{reset} %s\n", result_str);
             pizza_io_printf("{cyan}With Timestamp:{reset} %llu ns\n", test_case->elapsed_ns);
             pizza_io_printf("{blue}========================================{reset}\n");
             }
@@ -133,6 +138,8 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
             } else if (G_PIZZA_VERBOSE == PIZZA_VERBOSE_DOGE) {
             pizza_io_printf("{cyan}========================================{reset}\n");
             pizza_io_printf("{cyan}Test Case:{reset} %s\n", test_case->name);
+            pizza_io_printf("{cyan}Given Tags:{reset} %s\n", test_case->tags);
+            pizza_io_printf("{cyan}Given Criteria:{reset} %s\n", test_case->criteria);
             pizza_io_printf("{cyan}Given Result:{reset} %s\n", result_str);
             pizza_io_printf("{cyan}With Timestamp:{reset} %llu ns\n", test_case->elapsed_ns);
             pizza_io_printf("{cyan}========================================{reset}\n");
@@ -146,6 +153,8 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
             } else if (G_PIZZA_VERBOSE == PIZZA_VERBOSE_DOGE) {
             pizza_io_printf("{blue}[========================================]{reset}\n");
             pizza_io_printf("{blue}[Test Case]:{reset} %s\n", test_case->name);
+            pizza_io_printf("{blue}[Given Tags]:{reset} %s\n", test_case->tags);
+            pizza_io_printf("{blue}[Given Criteria]:{reset} %s\n", test_case->criteria);
             pizza_io_printf("{blue}[Given Result]:{reset} %s\n", result_str);
             pizza_io_printf("{blue}[With Timestamp]:{reset} %llu ns\n", test_case->elapsed_ns);
             pizza_io_printf("{blue}[========================================]{reset}\n");
@@ -159,6 +168,8 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
             } else if (G_PIZZA_VERBOSE == PIZZA_VERBOSE_DOGE) {
             pizza_io_printf("{green}# ========================================{reset}\n");
             pizza_io_printf("{green}# Test Case:{reset} %s\n", test_case->name);
+            pizza_io_printf("{green}# Given Tags:{reset} %s\n", test_case->tags);
+            pizza_io_printf("{green}# Given Criteria:{reset} %s\n", test_case->criteria);
             pizza_io_printf("{green}# Given Result:{reset} %s\n", result_str);
             pizza_io_printf("{green}# With Timestamp:{reset} %llu ns\n", test_case->elapsed_ns);
             pizza_io_printf("{green}# ========================================{reset}\n");
@@ -172,6 +183,8 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
             } else if (G_PIZZA_VERBOSE == PIZZA_VERBOSE_DOGE) {
             pizza_io_printf("{blue}[========================================]{reset}\n");
             pizza_io_printf("{blue}[Test Case]:{reset} %s\n", test_case->name);
+            pizza_io_printf("{blue}[Given Tags]:{reset} %s\n", test_case->tags);
+            pizza_io_printf("{blue}[Given Criteria]:{reset} %s\n", test_case->criteria);
             pizza_io_printf("{blue}[Given Result]:{reset} %s\n", result_str);
             pizza_io_printf("{blue}[With Timestamp]:{reset} %llu ns\n", test_case->elapsed_ns);
             pizza_io_printf("{blue}[========================================]{reset}\n");
@@ -185,6 +198,8 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
             } else if (G_PIZZA_VERBOSE == PIZZA_VERBOSE_DOGE) {
             pizza_io_printf("{magenta}========================================{reset}\n");
             pizza_io_printf("{magenta}Test Case:{reset} %s\n", test_case->name);
+            pizza_io_printf("{magenta}Given Tags:{reset} %s\n", test_case->tags);
+            pizza_io_printf("{magenta}Given Criteria:{reset} %s\n", test_case->criteria);
             pizza_io_printf("{magenta}Given Result:{reset} %s\n", result_str);
             pizza_io_printf("{magenta}With Timestamp:{reset} %llu ns\n", test_case->elapsed_ns);
             pizza_io_printf("{magenta}========================================{reset}\n");
@@ -198,12 +213,18 @@ void fossil_pizza_test_output(const fossil_pizza_case_t* test_case) {
             } else if (G_PIZZA_VERBOSE == PIZZA_VERBOSE_DOGE) {
             pizza_io_printf("{cyan}========================================{reset}\n");
             pizza_io_printf("{cyan}Test Case:{reset} %s\n", test_case->name);
+            pizza_io_printf("{cyan}Given Tags:{reset} %s\n", test_case->tags);
+            pizza_io_printf("{cyan}Given Criteria:{reset} %s\n", test_case->criteria);
             pizza_io_printf("{cyan}Given Result:{reset} %s\n", result_str);
             pizza_io_printf("{cyan}With Timestamp:{reset} %llu ns\n", test_case->elapsed_ns);
             pizza_io_printf("{cyan}========================================{reset}\n");
             }
             break;
     }
+}
+// Utility function to convert seconds to nanoseconds
+static uint64_t seconds_to_nanoseconds(uint64_t seconds) {
+    return seconds * 1000000000ULL;
 }
 
 void fossil_pizza_run_test(const fossil_pizza_engine_t* engine, fossil_pizza_case_t* test_case, fossil_pizza_suite_t* suite) {
@@ -225,7 +246,7 @@ void fossil_pizza_run_test(const fossil_pizza_engine_t* engine, fossil_pizza_cas
                     test_case->run();
                     uint64_t elapsed_time = fossil_pizza_now_ns() - start_time;
 
-                    if (1000000ULL > 0 && elapsed_time > 1000000ULL) {
+                    if (elapsed_time > seconds_to_nanoseconds(G_PIZZA_TIMEOUT)) { // 1 minute in nanoseconds
                         test_case->result = FOSSIL_PIZZA_CASE_TIMEOUT;
                     } else {
                         test_case->result = FOSSIL_PIZZA_CASE_PASS;
@@ -246,6 +267,10 @@ void fossil_pizza_run_test(const fossil_pizza_engine_t* engine, fossil_pizza_cas
         }
 
         // Output test case result
+        fossil_pizza_test_output(test_case);
+    } else if (test_case->result == FOSSIL_PIZZA_CASE_SKIPPED) {
+        // Output skipped test case result
+        test_case->elapsed_ns = 0; // No time elapsed for skipped tests
         fossil_pizza_test_output(test_case);
     } else {
         // Handle unexpected cases


### PR DESCRIPTION
# Fossil Test - Pull Request

## Description
Provide a way to toggle timeout value with the new timeout command which takes the in a number as seconds, set as 60 seconds by default.

## Testing
Same test.

## Checklist
- [ ] Code follows the project's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes.
- [ ] The code has been reviewed by team members.
- [ ] All checks and tests pass.
- [ ] The license header and notices are updated where necessary.

## License
This project is licensed under the Mozilla Public License - see the [LICENSE](LICENSE) file for details.
